### PR TITLE
Refactor vertical interpolation

### DIFF
--- a/src/idpi/operators/support_operators.py
+++ b/src/idpi/operators/support_operators.py
@@ -83,7 +83,8 @@ def init_field_with_vcoord(
         for dim, size in items:
             if dim == "generalVerticalLayer":
                 yield vcoord.type_of_level, vcoord.size
-            yield dim, size
+            else:
+                yield dim, size
 
     # ... make sure to maintain the ordering of the dims
     sizes = {dim: size for dim, size in replace_vertical(parent.sizes.items())}

--- a/src/idpi/operators/support_operators.py
+++ b/src/idpi/operators/support_operators.py
@@ -73,7 +73,7 @@ def init_field_with_vcoord(
     attrs = parent.attrs.copy()
     attrs["GRIB_typeOfLevel"] = vcoord.type_of_level
     if "GRIB_NV" in attrs:
-        attrs["GRIB_NV"] = vcoord.nv
+        attrs["GRIB_NV"] = 0
     # dims
     sizes = {dim: size for dim, size in parent.sizes.items() if str(dim) in "xy"}
     sizes[vcoord.type_of_level] = vcoord.size

--- a/src/idpi/operators/support_operators.py
+++ b/src/idpi/operators/support_operators.py
@@ -4,8 +4,8 @@
 # Standard library
 import dataclasses as dc
 from typing import Any
-from typing import Optional
 from typing import Literal
+from typing import Optional
 from typing import Sequence
 
 # Third-party

--- a/src/idpi/operators/support_operators.py
+++ b/src/idpi/operators/support_operators.py
@@ -47,21 +47,23 @@ def init_field_with_vcoord(
     Properties except for those related to the vertical coordinates,
     and optionally dtype, are inherited from the parent xarray.DataArray.
 
-    Args:
-        parent (xr.DataArray): parent field
-        vcoord (dict[str, Any]): dictionary specifying new vertical coordinates;
-            expected keys: "typeOfLevel" (string), "values" (list),
-                "NV" (int), "attrs" (dict)
-        fill_value (Any): value the data array of the new field
-            is initialized with
-        dtype (np.dtype, optional): fill value data type; defaults to None (in this case
-            the data type is inherited from the parent field). Defaults to None.
+    Parameters
+    ----------
+    parent : xr.DataArray
+        parent field
+    vcoord: TargetCoordinates
+        target vertical coordinates for the output field
+    fill_value : Any
+        value the data array of the new field is initialized with
+    dtype : np.dtype, optional
+        fill value data type; defaults to None (in this case
+        the data type is inherited from the parent field)
 
-    Raises:
-        KeyError: _description_
-
-    Returns:
-        xr.DataArray: new field
+    Returns
+    -------
+    xr.DataArray
+        new field located at the parent field horizontal coordinates, the target
+        coordinates in the vertical and filled with the given value
 
     """
     # TODO: test that vertical dim of parent is named "generalVerticalLayer"
@@ -73,6 +75,7 @@ def init_field_with_vcoord(
     attrs = parent.attrs.copy()
     attrs["GRIB_typeOfLevel"] = vcoord.type_of_level
     if "GRIB_NV" in attrs:
+        # NV is only non-zero when hybrid coordinates are in use
         attrs["GRIB_NV"] = 0
 
     # dims

--- a/src/idpi/operators/support_operators.py
+++ b/src/idpi/operators/support_operators.py
@@ -74,9 +74,16 @@ def init_field_with_vcoord(
     attrs["GRIB_typeOfLevel"] = vcoord.type_of_level
     if "GRIB_NV" in attrs:
         attrs["GRIB_NV"] = 0
+
     # dims
-    sizes = {dim: size for dim, size in parent.sizes.items() if str(dim) in "xy"}
-    sizes[vcoord.type_of_level] = vcoord.size
+    def replace_vertical(items):
+        for dim, size in items:
+            if dim == "generalVerticalLayer":
+                yield vcoord.type_of_level, vcoord.size
+            yield dim, size
+
+    # ... make sure to maintain the ordering of the dims
+    sizes = {dim: size for dim, size in replace_vertical(parent.sizes.items())}
     # coords
     # ... inherit all except for the vertical coordinates
     coords = {c: v for c, v in parent.coords.items() if c != "generalVerticalLayer"}

--- a/src/idpi/operators/vertical_interpolation.py
+++ b/src/idpi/operators/vertical_interpolation.py
@@ -1,14 +1,24 @@
 """Vertical interpolation operators."""
 
+from typing import Literal
+
 # Third-party
 import numpy as np
 import xarray as xr
 
 # First-party
 from idpi.operators.support_operators import init_field_with_vcoord
+from idpi.operators.support_operators import TargetCoordinates
+from idpi.operators.support_operators import TargetCoordinatesAttrs
 
 
-def interpolate_k2p(field, mode, p_field, p_tc_values, p_tc_units):
+def interpolate_k2p(
+    field: xr.DataArray,
+    mode: Literal["linear_in_p", "linear_in_lnp", "nearest_sfc"],
+    p_field: xr.DataArray,
+    p_tc_values: list[float],
+    p_tc_units: Literal["Pa", "hPa"],
+) -> xr.DataArray:
     """Interpolate a field from model (k) levels to pressure coordinates.
 
     Example for vertical interpolation to isosurfaces of a target field,
@@ -62,28 +72,23 @@ def interpolate_k2p(field, mode, p_field, p_tc_values, p_tc_units):
     supported_vc_type = "generalVerticalLayer"
 
     # Define vertical target coordinates (tc)
-    tc = dict()
-    tc_values = p_tc_values.copy()
-    tc_values.sort(reverse=False)
     tc_factor = p_tc_unit_conversions[p_tc_units]
-    tc["values"] = np.array(tc_values) * tc_factor
-    if min(tc["values"]) < p_tc_min or max(tc["values"]) > p_tc_max:
+    tc_values = np.array(sorted(p_tc_values)) * tc_factor
+    if np.any((tc_values < p_tc_min) | (tc_values > p_tc_max)):
         raise RuntimeError(
             "interpolate_k2p: target coordinate value out of range "
-            "(must be in interval [",
-            p_tc_min,
-            ", ",
-            p_tc_max,
-            "]Pa)",
+            f"(must be in interval [{p_tc_min}, {p_tc_max}]Pa)"
         )
-    tc["attrs"] = {
-        "units": "Pa",
-        "positive": "down",
-        "standard_name": "air_pressure",
-        "long_name": "pressure",
-    }
-    tc["typeOfLevel"] = "isobaricInPa"
-    tc["NV"] = 0
+    tc = TargetCoordinates(
+        type_of_level="isobaricInPa",
+        values=tc_values.tolist(),
+        attrs=TargetCoordinatesAttrs(
+            units="Pa",
+            positive="down",
+            standard_name="air_pressure",
+            long_name="pressure",
+        ),
+    )
 
     # Check that typeOfLevel is supported and equal for both field and p_field
     if supported_vc_type not in field.dims:
@@ -107,31 +112,11 @@ def interpolate_k2p(field, mode, p_field, p_tc_values, p_tc_units):
 
     # Interpolate
     # ... prepare interpolation
-    pkm1 = p_field.copy()
-    pkm1[{"generalVerticalLayer": slice(1, None)}] = p_field[
-        {"generalVerticalLayer": slice(0, -1)}
-    ].assign_coords(
-        {
-            "generalVerticalLayer": p_field[
-                {"generalVerticalLayer": slice(1, None)}
-            ].generalVerticalLayer
-        }
-    )
-    pkm1[{"generalVerticalLayer": 0}] = np.nan
-    fkm1 = field.copy()
-    fkm1[{"generalVerticalLayer": slice(1, None)}] = field[
-        {"generalVerticalLayer": slice(0, -1)}
-    ].assign_coords(
-        {
-            "generalVerticalLayer": field[
-                {"generalVerticalLayer": slice(1, None)}
-            ].generalVerticalLayer
-        }
-    )
-    fkm1[{"generalVerticalLayer": 0}] = np.nan
+    pkm1 = p_field.shift(generalVerticalLayer=1)
+    fkm1 = field.shift(generalVerticalLayer=1)
 
     # ... loop through tc values
-    for tc_idx, p0 in enumerate(tc["values"]):
+    for tc_idx, p0 in enumerate(tc_values):
         # ... find the 3d field where pressure is > p0 on level k
         # and was <= p0 on level k-1
         p2 = p_field.where((p_field > p0) & (pkm1 <= p0))
@@ -167,12 +152,19 @@ def interpolate_k2p(field, mode, p_field, p_tc_values, p_tc_units):
             ratio = xr.where(np.abs(p0 - p1) >= np.abs(p0 - p2), 1.0, 0.0)
 
         # ... interpolate and update field_on_tc
-        field_on_tc[{tc["typeOfLevel"]: tc_idx}] = (1.0 - ratio) * f1 + ratio * f2
+        field_on_tc[{tc.type_of_level: tc_idx}] = (1.0 - ratio) * f1 + ratio * f2
 
     return field_on_tc
 
 
-def interpolate_k2theta(field, mode, th_field, th_tc_values, th_tc_units, h_field):
+def interpolate_k2theta(
+    field: xr.DataArray,
+    mode: Literal["low_fold", "high_fold", "undef_fold"],
+    th_field: xr.DataArray,
+    th_tc_values: list[float],
+    th_tc_units: Literal["K", "cK"],
+    h_field: xr.DataArray,
+) -> xr.DataArray:
     """Interpolate a field from model levels to potential temperature coordinates.
 
        Example for vertical interpolation to isosurfaces of a target field
@@ -183,7 +175,7 @@ def interpolate_k2theta(field, mode, th_field, th_tc_values, th_tc_units, h_fiel
     field : xarray.DataArray
         field to interpolate (only typeOfLevel="generalVerticalLayer" is supported)
     mode : str
-        interpolation algorithm, one of {"low_fold", "high_fold","undef_fold"}
+        interpolation algorithm, one of {"low_fold", "high_fold", "undef_fold"}
     th_field : xarray.DataArray
         potential temperature theta on k levels in K
         (only typeOfLevel="generalVerticalLayer" is supported)
@@ -239,29 +231,24 @@ def interpolate_k2theta(field, mode, th_field, th_tc_values, th_tc_units, h_fiel
     supported_vc_type = "generalVerticalLayer"
 
     # Define vertical target coordinates
-    tc = dict()
-    tc_values = th_tc_values.copy()
-    tc_values.sort(reverse=False)
     # Sorting cannot be exploited for optimizations, since theta is
     # not monotonous wrt to height tc values are stored in K
-    tc["values"] = np.array(th_tc_values) * th_tc_unit_conversions[th_tc_units]
-    if min(tc["values"]) < th_tc_min or max(tc["values"]) > th_tc_max:
+    tc_values = np.array(th_tc_values) * th_tc_unit_conversions[th_tc_units]
+    if np.any((tc_values < th_tc_min) | (tc_values > th_tc_max)):
         raise RuntimeError(
             "interpolate_k2theta: target coordinate value "
-            "out of range (must be in interval [",
-            th_tc_min,
-            ", ",
-            th_tc_max,
-            "]K)",
+            f"out of range (must be in interval [{th_tc_min}, {th_tc_max}]K)"
         )
-    tc["attrs"] = {
-        "units": "K",
-        "positive": "up",
-        "standard_name": "air_potential_temperature",
-        "long_name": "potential temperature",
-    }
-    tc["typeOfLevel"] = "theta"
-    tc["NV"] = 0
+    tc = TargetCoordinates(
+        type_of_level="theta",
+        values=tc_values.tolist(),
+        attrs=TargetCoordinatesAttrs(
+            units="K",
+            positive="up",
+            standard_name="air_potential_temperature",
+            long_name="potential temperature",
+        ),
+    )
 
     # Check that typeOfLevel is supported and equal for field, th_field, and h_field
     if supported_vc_type not in field.dims:
@@ -286,32 +273,11 @@ def interpolate_k2theta(field, mode, th_field, th_tc_values, th_tc_units, h_fiel
 
     # Interpolate
     # ... prepare interpolation
-    thkm1 = th_field.copy()
-    thkm1[{"generalVerticalLayer": slice(1, None)}] = th_field[
-        {"generalVerticalLayer": slice(0, -1)}
-    ].assign_coords(
-        {
-            "generalVerticalLayer": th_field[
-                {"generalVerticalLayer": slice(1, None)}
-            ].generalVerticalLayer
-        }
-    )
-    thkm1[{"generalVerticalLayer": 0}] = np.nan
-
-    fkm1 = field.copy()
-    fkm1[{"generalVerticalLayer": slice(1, None)}] = field[
-        {"generalVerticalLayer": slice(0, -1)}
-    ].assign_coords(
-        {
-            "generalVerticalLayer": field[
-                {"generalVerticalLayer": slice(1, None)}
-            ].generalVerticalLayer
-        }
-    )
-    fkm1[{"generalVerticalLayer": 0}] = np.nan
+    thkm1 = th_field.shift(generalVerticalLevel=1)
+    fkm1 = field.shift(generalVerticalLayer=1)
 
     # ... loop through tc values
-    for tc_idx, th0 in enumerate(tc["values"]):
+    for tc_idx, th0 in enumerate(tc.values):
         folding_coord_exception = xr.full_like(
             h_field[{"generalVerticalLayer": 0}], False
         )
@@ -350,7 +316,7 @@ def interpolate_k2theta(field, mode, th_field, th_tc_values, th_tc_units, h_fiel
         ratio = xr.where(np.abs(th2 - th1) > 0, (th0 - th1) / (th2 - th1), 0.0)
 
         # ... interpolate and update field_on_tc
-        field_on_tc[{tc["typeOfLevel"]: tc_idx}] = xr.where(
+        field_on_tc[{tc.type_of_level: tc_idx}] = xr.where(
             folding_coord_exception, np.nan, (1.0 - ratio) * f1 + ratio * f2
         )
 

--- a/src/idpi/operators/vertical_interpolation.py
+++ b/src/idpi/operators/vertical_interpolation.py
@@ -274,7 +274,7 @@ def interpolate_k2theta(
 
     # Interpolate
     # ... prepare interpolation
-    thkm1 = th_field.shift(generalVerticalLevel=1)
+    thkm1 = th_field.shift(generalVerticalLayer=1)
     fkm1 = field.shift(generalVerticalLayer=1)
 
     # ... loop through tc values

--- a/src/idpi/operators/vertical_interpolation.py
+++ b/src/idpi/operators/vertical_interpolation.py
@@ -1,5 +1,6 @@
 """Vertical interpolation operators."""
 
+# Standard library
 from typing import Literal
 
 # Third-party


### PR DESCRIPTION
## Purpose

Prepare the upcoming changes related to the move to earthkit data and the new metamodel design. 

## Code changes:

- Introduce the TargetCoordinates class to describe the target vertical coordinates. This is done to avoid the use of dict typing which is a form of code smell.
- Simplify the dimensions handling in `init_field_with_vcoord`
- Added some missing type hints, use Literal to indicate the possible choices for string parameters


