### PR TITLE
Use earthkit.data

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ where = ["src"]
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 addopts = [
-    "-s",
+
     "-ra",
     "--pdbcls=IPython.terminal.debugger:TerminalPdb",
 	"--tb=short",

--- a/requirements/requirements.yaml
+++ b/requirements/requirements.yaml
@@ -6,11 +6,12 @@ dependencies:
   - pip>=22.3
   # runtime
   - click>=8.1
-  - cfgrib>=0.9.10.1
+  - eccodes>=2.25.0
+  - earthkit-data>=0.1.3
   - jinja2>=3.1.1
-  - netcdf4>=1.5.8
-  - eccodes=2.25.0
-  - numpy >=1.23
+  - numpy>=1.23
+  - python-eccodes>=1.5.1
+  - xarray>=2023.4.1
   # development
   - anaconda-client>=1.11
   - black>=22.10

--- a/src/idpi/grib_decoder.py
+++ b/src/idpi/grib_decoder.py
@@ -1,26 +1,134 @@
 """Decoder for grib data."""
+# Standard library
+import os
+from contextlib import contextmanager
+from pathlib import Path
+
 # Third-party
-import cfgrib  # type: ignore
+import earthkit.data  # type: ignore
+import eccodes  # type: ignore
+import numpy as np
+import xarray as xr
 
 
-def load_data(outds, fields, datafile, chunk_size=10):
-    chunk_arg = {}
-    if chunk_size:
-        chunk_arg = {"chunks": {"generalVerticalLayer": chunk_size}}
-
-    # Note: dataset assignment is based on typeOfLevel in cfgrib
-    dss = cfgrib.open_datasets(
-        datafile,
-        backend_kwargs={"read_keys": ["typeOfLevel", "gridType"]},
-        encode_cf=("time", "geography", "vertical"),
-        **chunk_arg,
+@contextmanager
+def cosmo_grib_defs():
+    """Enable COSMO GRIB definitions."""
+    prefix = os.environ["CONDA_PREFIX"]
+    root_dir = Path(prefix) / "share"
+    paths = (
+        root_dir / "eccodes-cosmo-resources/definitions",
+        root_dir / "eccodes/definitions",
     )
-    for ds in dss:
-        for field in fields:
-            if field in ds:
-                outds[field] = ds[field]
-                if field == "HHL":
-                    outds[field] = outds[field].interpolate_na(dim="generalVertical")
+    for path in paths:
+        if not path.exists():
+            raise RuntimeError(f"{path} does not exist")
+    defs_path = ":".join(map(str, paths))
+    restore = eccodes.codes_definition_path()
+    eccodes.codes_set_definitions_path(defs_path)
+    try:
+        yield
+    finally:
+        eccodes.codes_set_definitions_path(restore)
 
-    if any(field not in outds for field in fields):
-        raise RuntimeError("Not all fields found in datafile", fields)
+
+def load_data(
+    params: list[str], datafiles: list[Path], ref_param: str
+) -> dict[str, xr.DataArray]:
+    """Load data from GRIB files.
+
+    Parameters
+    ----------
+    params : list[str]
+        List of fields to load from the data files.
+    datafiles : list[Path]
+        List of files from which to load the data.
+    ref_param : str
+        Parameter to use as a reference for the coordinates.
+
+    Raises
+    ------
+    ValueError
+        if ref_param is not included in params.
+    RuntimeError
+        if not all fields are found in the given datafiles.
+
+    Returns
+    -------
+    dict[str, xr.DataArray]
+        Mapping of fields by param name
+
+    """
+    fs = earthkit.data.from_source("file", [str(p) for p in datafiles])
+
+    if ref_param not in params:
+        raise ValueError(f"{ref_param} must be in {params}")
+
+    hcoords = None
+    metadata = {}
+    level_types = {}
+    data: dict[str, dict[int, np.ndarray]] = {}
+    for f in fs.sel(param=params):
+        param = f.metadata("param")
+        levels = data.setdefault(param, {})
+        levels[f.metadata("level")] = f.to_numpy(dtype=np.float32)
+
+        if param not in level_types:
+            level_types[param] = f.metadata("typeOfLevel")
+
+        if param not in metadata:
+            metadata[param] = f.metadata(
+                namespace=["ls", "geography", "parameter", "time"]
+            )
+
+        if hcoords is None and param == ref_param:
+            hcoords = {
+                dim: (("y", "x"), values) for dim, values in f.to_points().items()
+            }
+
+    if not set(params) == data.keys():
+        raise RuntimeError("Not all parameters were loaded")
+
+    return {
+        param: xr.DataArray(
+            np.array([levels.pop(k) for k in sorted(levels)]),
+            coords=hcoords,
+            dims=[level_types[param], "y", "x"],
+            attrs=metadata[param],
+        )
+        for param, levels in data.items()
+    }
+
+
+def load_cosmo_data(
+    params: list[str], datafiles: list[Path], ref_param: str = "HHL"
+) -> dict[str, xr.DataArray]:
+    """Load data from GRIB files.
+
+    The COSMO definitions are enabled during the load.
+
+    Parameters
+    ----------
+    params : list[str]
+        List of fields to load from the data files.
+    datafiles : list[Path]
+        List of files from which to load the data.
+    ref_param : str
+        Parameter to use as a reference for the coordinates.
+
+    Raises
+    ------
+    ValueError
+        if ref_param is not included in params.
+    RuntimeError
+        if not all fields are found in the given datafiles.
+
+
+    Returns
+    -------
+    dict[str, xr.DataArray]
+        Mapping of fields by param name
+
+    """
+    with cosmo_grib_defs():
+        return load_data(params, datafiles, ref_param)

--- a/src/idpi/operators/brn.py
+++ b/src/idpi/operators/brn.py
@@ -15,8 +15,10 @@ def fbrn(p, t, qv, u, v, hhl, hsurf):
     nlevels = len(p.coords["generalVerticalLayer"])
 
     thetav = fthetav(p, t, qv)
-    thetav_sum = thetav.isel(generalVerticalLayer=slice(None, None, -1)).cumsum(
-        dim="generalVerticalLayer"
+    thetav_sum = (
+        thetav.isel(generalVerticalLayer=slice(None, None, -1))
+        .cumsum(dim="generalVerticalLayer")
+        .isel(generalVerticalLayer=slice(None, None, -1))
     )
 
     nlevels_xr = xr.DataArray(
@@ -28,7 +30,7 @@ def fbrn(p, t, qv, u, v, hhl, hsurf):
 
     brn = (
         pc_g
-        * (hfl - hsurf)
+        * (hfl - hsurf.squeeze())
         * (thetav - thetav.isel(generalVerticalLayer=nlevels - 1))
         * nlevels_xr
         / (thetav_sum * (u_**2 + v_**2))

--- a/src/idpi/operators/destagger.py
+++ b/src/idpi/operators/destagger.py
@@ -119,7 +119,6 @@ def destagger(
                 exclude_dims={dim},
             )
             .transpose(*dims)
-            .assign_coords({dim: field.generalVertical[:-1]})
             .rename({"generalVertical": "generalVerticalLayer"})
         )
 

--- a/src/idpi/operators/pot_vortic.py
+++ b/src/idpi/operators/pot_vortic.py
@@ -8,7 +8,7 @@ import xarray as xr
 from .. import constants as const
 from . import diff
 from .curl import curl
-from .support_operators import get_rotated_latitude
+from .support_operators import get_grid_coords
 from .total_diff import TotalDiff
 
 
@@ -57,8 +57,13 @@ def fpotvortic(
     """
     # target coordinates
     deg2rad = np.pi / 180
-    lat = (rho_tot["latitude"] * deg2rad).astype(np.float32)
-    rlat = get_rotated_latitude(w)
+    lat = (rho_tot["lat"] * deg2rad).astype(np.float32)
+
+    geo = w.attrs["geography"]
+    ny = geo["Nj"]
+    lat_min = geo["latitudeOfFirstGridPointInDegrees"]
+    dlat = geo["jDirectionIncrementInDegrees"]
+    rlat = get_grid_coords(ny, lat_min, dlat, "y") * deg2rad
 
     # compute curl
     curl1, curl2, curl3 = curl(u, v, w, rlat, total_diff)

--- a/src/idpi/operators/support_operators.py
+++ b/src/idpi/operators/support_operators.py
@@ -108,9 +108,24 @@ def init_field_with_vcoord(
     )
 
 
-def get_rotated_latitude(field: xr.DataArray) -> xr.DataArray:
-    ny = field.attrs["GRIB_Ny"]
-    lat_min = field.attrs["GRIB_latitudeOfFirstGridPointInDegrees"]
-    dlat = field.attrs["GRIB_jDirectionIncrementInDegrees"]
-    rlat = xr.DataArray(np.arange(ny, dtype=np.float32) * dlat + lat_min, dims="y")
-    return rlat * np.pi / 180
+def get_grid_coords(n: int, x0: float, dx: float, dim: str) -> xr.DataArray:
+    """Compute coordinates for an equally spaced grid.
+
+    Parameters
+    ----------
+    n : int
+        Number of grid points
+    x0 : float
+        Coordinates of the origin in the given dimension
+    dx : float
+        Spacing of the grid along the given dimension
+    dim : str
+        Dimension along which the grid is defined
+
+    Returns
+    -------
+    xr.DataArray
+        A 1-D field containing the coordinates of the grid along the given dimension
+
+    """
+    return xr.DataArray(np.arange(n, dtype=np.float32) * dx + x0, dims=dim)

--- a/src/idpi/products/ninjo_k2th.py
+++ b/src/idpi/products/ninjo_k2th.py
@@ -38,8 +38,9 @@ def _compute_pot_vortic(
     rho_tot = f_rho_tot(T, P, QV, QC, QI)
 
     logger.info("Computing terrain following grid deformation factors")
-    dlon = HHL.attrs["GRIB_iDirectionIncrementInDegrees"]
-    dlat = HHL.attrs["GRIB_jDirectionIncrementInDegrees"]
+    geo = HHL.attrs["geography"]
+    dlon = geo["iDirectionIncrementInDegrees"]
+    dlat = geo["jDirectionIncrementInDegrees"]
     deg2rad = np.pi / 180
     total_diff = TotalDiff(dlon * deg2rad, dlat * deg2rad, HHL)
 

--- a/src/idpi/products/ninjo_k2th.py
+++ b/src/idpi/products/ninjo_k2th.py
@@ -55,7 +55,8 @@ def _compute_mean(
     pressure: xr.DataArray,
 ) -> xr.DataArray:
     logger.info("Computing mean potential vorticity between 700 and 900 hPa")
-    h700, h900 = interpolate_k2p(hfl, "linear_in_lnp", pressure, [700, 900], "hPa")
+    isobars = interpolate_k2p(hfl, "linear_in_lnp", pressure, [700, 900], "hPa")
+    h700, h900 = isobars.transpose("isobaricInPa", ...)
     return integrate_k(pot_vortic, "normed_integral", "z2z", hhl, (h900, h700))
 
 

--- a/tests/test_idpi/conftest.py
+++ b/tests/test_idpi/conftest.py
@@ -1,7 +1,6 @@
 """Test configuration."""
 
 # Standard library
-import os
 import subprocess
 from pathlib import Path
 
@@ -54,24 +53,3 @@ def fieldextra(tmp_path, data_dir, template_env, fieldextra_executable):
         return [xr.open_dataset(tmp_path / f"{h:02d}_{field_name}.nc") for h in hh]
 
     return f
-
-
-@pytest.fixture
-def grib_defs():
-    """Setup COSMO GRIB definitions."""
-    # Third-party
-    import eccodes  # type: ignore
-
-    prefix = os.environ["CONDA_PREFIX"]
-    root_dir = Path(prefix) / "share"
-    paths = (
-        root_dir / "eccodes-cosmo-resources/definitions",
-        root_dir / "eccodes/definitions",
-    )
-    for path in paths:
-        assert path.exists(), f"{path} does not exist"
-    defs_path = ":".join(map(str, paths))
-    restore = eccodes.codes_definition_path()
-    eccodes.codes_set_definitions_path(defs_path)
-    yield
-    eccodes.codes_set_definitions_path(restore)

--- a/tests/test_idpi/test_brn.py
+++ b/tests/test_idpi/test_brn.py
@@ -20,10 +20,5 @@ def test_brn(data_dir, fieldextra):
     )
 
     fs_ds = fieldextra("BRN")
-    brn_ref = (
-        fs_ds["BRN"]
-        .rename({"x_1": "x", "y_1": "y", "z_1": "generalVerticalLayer"})
-        .squeeze()
-    )
 
-    assert_allclose(brn_ref, brn, rtol=5e-3, atol=5e-2, equal_nan=True)
+    assert_allclose(fs_ds["BRN"], brn, rtol=5e-3, atol=5e-2)

--- a/tests/test_idpi/test_brn.py
+++ b/tests/test_idpi/test_brn.py
@@ -6,13 +6,14 @@ import idpi.operators.brn as mbrn
 from idpi import grib_decoder
 
 
-def test_brn(data_dir, fieldextra, grib_defs):
+def test_brn(data_dir, fieldextra):
     datafile = data_dir / "lfff00000000.ch"
     cdatafile = data_dir / "lfff00000000c.ch"
 
-    ds = {}
-    grib_decoder.load_data(ds, ["P", "T", "QV", "U", "V"], datafile, chunk_size=None)
-    grib_decoder.load_data(ds, ["HHL", "HSURF"], cdatafile, chunk_size=None)
+    ds = grib_decoder.load_cosmo_data(
+        ["P", "T", "QV", "U", "V", "HHL", "HSURF"],
+        [datafile, cdatafile],
+    )
 
     brn = mbrn.fbrn(
         ds["P"], ds["T"], ds["QV"], ds["U"], ds["V"], ds["HHL"], ds["HSURF"]

--- a/tests/test_idpi/test_curl.py
+++ b/tests/test_idpi/test_curl.py
@@ -9,6 +9,7 @@ from xarray.testing import assert_allclose
 # First-party
 from idpi import grib_decoder
 from idpi.operators import curl
+from idpi.operators.support_operators import get_grid_coords
 from idpi.operators.total_diff import TotalDiff
 
 
@@ -20,25 +21,26 @@ def print_time(name):
     print(f"{name} took {elapsed:.3f} s")
 
 
-def test_curl(data_dir, grib_defs):
+def test_curl(data_dir):
     datafile = data_dir / "lfff00000000.ch"
     cdatafile = data_dir / "lfff00000000c.ch"
 
-    ds = {}
-    grib_decoder.load_data(ds, ["U", "V", "W"], datafile, chunk_size=None)
-    grib_decoder.load_data(ds, ["HHL", "HSURF"], cdatafile, chunk_size=None)
+    ds = grib_decoder.load_cosmo_data(["U", "V", "W", "HHL"], [datafile, cdatafile])
 
-    dlon = ds["HHL"].attrs["GRIB_iDirectionIncrementInDegrees"]
-    dlat = ds["HHL"].attrs["GRIB_jDirectionIncrementInDegrees"]
+    geo = ds["HHL"].attrs["geography"]
+    dlon = geo["iDirectionIncrementInDegrees"]
+    dlat = geo["jDirectionIncrementInDegrees"]
+    nj = geo["Nj"]
+    lat_min = geo["latitudeOfFirstGridPointInDegrees"]
+
     deg2rad = np.pi / 180
-
+    rlat = get_grid_coords(nj, lat_min, dlat, "y") * deg2rad
     total_diff = TotalDiff(dlon * deg2rad, dlat * deg2rad, ds["HHL"])
-    lat = ds["HHL"]["latitude"] * deg2rad
 
     with print_time("curl"):
-        a1, a2, a3 = curl.curl(ds["U"], ds["V"], ds["W"], lat, total_diff)
+        a1, a2, a3 = curl.curl(ds["U"], ds["V"], ds["W"], rlat, total_diff)
     with print_time("curl_alt"):
-        b1, b2, b3 = curl.curl_alt(ds["U"], ds["V"], ds["W"], lat, total_diff)
+        b1, b2, b3 = curl.curl_alt(ds["U"], ds["V"], ds["W"], rlat, total_diff)
 
     s = dict(x=slice(1, -1), y=slice(1, -1), generalVerticalLayer=slice(1, -1))
     assert_allclose(a1[s], b1[s])

--- a/tests/test_idpi/test_destagger.py
+++ b/tests/test_idpi/test_destagger.py
@@ -20,10 +20,7 @@ def test_destagger(data_dir, fieldextra):
     hfl = destagger(ds["HHL"], "generalVertical")
 
     fs_ds = fieldextra("destagger")
-    fields = ["U", "V", "HFL"]
-    name_map = {"x_1": "x", "y_1": "y", "z_1": "generalVerticalLayer"}
-    ref = {k: fs_ds[k].rename(name_map).squeeze() for k in fields}
 
-    assert_allclose(ref["U"], u, rtol=1e-12, atol=1e-9, equal_nan=True)
-    assert_allclose(ref["V"], v, rtol=1e-12, atol=1e-9, equal_nan=True)
-    assert_allclose(ref["HFL"], hfl, rtol=1e-12, atol=1e-9, equal_nan=True)
+    assert_allclose(fs_ds["U"], u, rtol=1e-12, atol=1e-9)
+    assert_allclose(fs_ds["V"], v, rtol=1e-12, atol=1e-9)
+    assert_allclose(fs_ds["HFL"], hfl, rtol=1e-12, atol=1e-9)

--- a/tests/test_idpi/test_destagger.py
+++ b/tests/test_idpi/test_destagger.py
@@ -6,13 +6,14 @@ from idpi import grib_decoder
 from idpi.operators.destagger import destagger
 
 
-def test_destagger(data_dir, fieldextra, grib_defs):
+def test_destagger(data_dir, fieldextra):
     datafile = data_dir / "lfff00000000.ch"
     cdatafile = data_dir / "lfff00000000c.ch"
 
-    ds = {}
-    grib_decoder.load_data(ds, ["U", "V"], datafile, chunk_size=None)
-    grib_decoder.load_data(ds, ["HHL"], cdatafile, chunk_size=None)
+    ds = grib_decoder.load_cosmo_data(
+        ["U", "V", "HHL"],
+        [datafile, cdatafile],
+    )
 
     u = destagger(ds["U"], "x")
     v = destagger(ds["V"], "y")

--- a/tests/test_idpi/test_destagger.py
+++ b/tests/test_idpi/test_destagger.py
@@ -23,4 +23,4 @@ def test_destagger(data_dir, fieldextra):
 
     assert_allclose(fs_ds["U"], u, rtol=1e-12, atol=1e-9)
     assert_allclose(fs_ds["V"], v, rtol=1e-12, atol=1e-9)
-    assert_allclose(fs_ds["HFL"], hfl, rtol=1e-12, atol=1e-9)
+    assert_allclose(fs_ds["HFL"], hfl.isel(step=0), rtol=1e-12, atol=1e-9)

--- a/tests/test_idpi/test_diff.py
+++ b/tests/test_idpi/test_diff.py
@@ -19,14 +19,15 @@ def test_masspoint_field(data_dir):
 
     theta = ftheta(ds["P"], ds["T"])
 
-    tp = np.pad(theta, 1, mode="edge")
-    tp[:, :, 0] = tp[:, :, -1] = np.nan
-    tp[:, 0, :] = tp[:, -1, :] = np.nan
-    dt_dx = 0.5 * (tp[1:-1, 1:-1, 2:] - tp[1:-1, 1:-1, :-2])
-    dt_dy = 0.5 * (tp[1:-1, 2:, 1:-1] - tp[1:-1, :-2, 1:-1])
-    dt_dz = 0.5 * (tp[2:, 1:-1, 1:-1] - tp[:-2, 1:-1, 1:-1])
-    dt_dz[0, :, :] *= 2
-    dt_dz[-1, :, :] *= 2
+    padding = [(0, 0)] * 2 + [(1, 1)] * 3
+    tp = np.pad(theta, padding, mode="edge")
+    tp[..., :, :, 0] = tp[..., :, :, -1] = np.nan
+    tp[..., :, 0, :] = tp[..., :, -1, :] = np.nan
+    dt_dx = 0.5 * (tp[..., 1:-1, 1:-1, 2:] - tp[..., 1:-1, 1:-1, :-2])
+    dt_dy = 0.5 * (tp[..., 1:-1, 2:, 1:-1] - tp[..., 1:-1, :-2, 1:-1])
+    dt_dz = 0.5 * (tp[..., 2:, 1:-1, 1:-1] - tp[..., :-2, 1:-1, 1:-1])
+    dt_dz[..., 0, :, :] *= 2
+    dt_dz[..., -1, :, :] *= 2
 
     assert_allclose(diff.dx(theta), dt_dx)
     assert_allclose(diff.dy(theta), dt_dy)
@@ -44,6 +45,6 @@ def test_staggered_field(data_dir):
 
     w = ds["W"]
     wn = w.to_numpy()
-    dw_dz = wn[1:] - wn[:-1]
+    dw_dz = wn[..., 1:, :, :] - wn[..., :-1, :, :]
 
     assert_allclose(diff.dz_staggered(w), dw_dz)

--- a/tests/test_idpi/test_diff.py
+++ b/tests/test_idpi/test_diff.py
@@ -8,11 +8,14 @@ from idpi.operators import diff
 from idpi.operators.theta import ftheta
 
 
-def test_masspoint_field(data_dir, grib_defs):
+def test_masspoint_field(data_dir):
     datafile = data_dir / "lfff00000000.ch"
 
-    ds = {}
-    grib_decoder.load_data(ds, ["P", "T"], datafile, chunk_size=None)
+    ds = grib_decoder.load_cosmo_data(
+        ["P", "T"],
+        [datafile],
+        ref_param="P",
+    )
 
     theta = ftheta(ds["P"], ds["T"])
 
@@ -30,11 +33,14 @@ def test_masspoint_field(data_dir, grib_defs):
     assert_allclose(diff.dz(theta), dt_dz)
 
 
-def test_staggered_field(data_dir, grib_defs):
+def test_staggered_field(data_dir):
     datafile = data_dir / "lfff00000000.ch"
 
-    ds = {}
-    grib_decoder.load_data(ds, ["W"], datafile, chunk_size=None)
+    ds = grib_decoder.load_cosmo_data(
+        ["W"],
+        [datafile],
+        ref_param="W",
+    )
 
     w = ds["W"]
     wn = w.to_numpy()

--- a/tests/test_idpi/test_hzerocl.py
+++ b/tests/test_idpi/test_hzerocl.py
@@ -6,13 +6,14 @@ from idpi import grib_decoder
 from idpi.operators.hzerocl import fhzerocl
 
 
-def test_hzerocl(data_dir, fieldextra, grib_defs):
+def test_hzerocl(data_dir, fieldextra):
     datafile = data_dir / "lfff00000000.ch"
     cdatafile = data_dir / "lfff00000000c.ch"
 
-    ds = {}
-    grib_decoder.load_data(ds, ["T"], datafile, chunk_size=None)
-    grib_decoder.load_data(ds, ["HHL"], cdatafile, chunk_size=None)
+    ds = grib_decoder.load_cosmo_data(
+        ["T", "HHL"],
+        [datafile, cdatafile],
+    )
 
     hzerocl = fhzerocl(ds["T"], ds["HHL"])
 

--- a/tests/test_idpi/test_hzerocl.py
+++ b/tests/test_idpi/test_hzerocl.py
@@ -18,10 +18,9 @@ def test_hzerocl(data_dir, fieldextra):
     hzerocl = fhzerocl(ds["T"], ds["HHL"])
 
     fs_ds = fieldextra("hzerocl")
-    hzerocl_ref = fs_ds["HZEROCL"].rename({"x_1": "x", "y_1": "y"}).squeeze()
 
     assert_allclose(
-        hzerocl_ref,
+        fs_ds["HZEROCL"],
         hzerocl,
         rtol=1e-6,
         atol=1e-5,

--- a/tests/test_idpi/test_integ_sfc2z.py
+++ b/tests/test_idpi/test_integ_sfc2z.py
@@ -32,7 +32,7 @@ def test_integ_sfc2z(field, k_max, operator, fx_op, atol, rtol, data_dir, fielde
     hhl = ds["HHL"]
     hfl = destagger(hhl, "generalVertical")
     hsurf = ds["HSURF"]
-    h_bounds = [hsurf.squeeze(), hfl[k_top - 1]]
+    h_bounds = [hsurf.squeeze(), hfl.isel(generalVerticalLayer=k_top - 1)]
 
     # call integral operator
     f_bar = integrate_k(ds[field], operator, mode, hhl, h_bounds)
@@ -45,13 +45,10 @@ def test_integ_sfc2z(field, k_max, operator, fx_op, atol, rtol, data_dir, fielde
         ktop=k_top,
         kmax=k_max,
     )
-    f_bar_ref = (
-        fx_ds[field].rename({"x_1": "x", "y_1": "y", "epsd_1": "number"}).squeeze()
-    )
 
     # compare numerical results
     assert_allclose(
-        f_bar_ref,
+        fx_ds[field],
         f_bar,
         rtol=rtol,
         atol=atol,

--- a/tests/test_idpi/test_integ_sfc2z.py
+++ b/tests/test_idpi/test_integ_sfc2z.py
@@ -48,7 +48,7 @@ def test_integ_sfc2z(field, k_max, operator, fx_op, atol, rtol, data_dir, fielde
 
     # compare numerical results
     assert_allclose(
-        fx_ds[field],
+        fx_ds[field].isel(z_1=0),
         f_bar,
         rtol=rtol,
         atol=atol,

--- a/tests/test_idpi/test_integ_sfc2z.py
+++ b/tests/test_idpi/test_integ_sfc2z.py
@@ -13,9 +13,7 @@ from idpi.operators.vertical_reduction import integrate_k
     "operator,fx_op,atol,rtol",
     [("integral", "integ", 1e-4, 1e-6), ("normed_integral", "norm_integ", 1e-5, 1e-6)],
 )
-def test_integ_sfc2z(
-    field, k_max, operator, fx_op, atol, rtol, data_dir, fieldextra, grib_defs
-):
+def test_integ_sfc2z(field, k_max, operator, fx_op, atol, rtol, data_dir, fieldextra):
     datafile = data_dir / "lfff00000000.ch"
     cdatafile = data_dir / "lfff00000000c.ch"
 
@@ -26,14 +24,15 @@ def test_integ_sfc2z(
     k_top = 61
 
     # load input data set
-    ds = {}
-    grib_decoder.load_data(ds, [field], datafile, chunk_size=None)
-    grib_decoder.load_data(ds, ["HHL", "HSURF"], cdatafile, chunk_size=None)
+    ds = grib_decoder.load_cosmo_data(
+        [field, "HHL", "HSURF"],
+        [datafile, cdatafile],
+    )
 
     hhl = ds["HHL"]
     hfl = destagger(hhl, "generalVertical")
     hsurf = ds["HSURF"]
-    h_bounds = [hsurf, hfl[k_top - 1]]
+    h_bounds = [hsurf.squeeze(), hfl[k_top - 1]]
 
     # call integral operator
     f_bar = integrate_k(ds[field], operator, mode, hhl, h_bounds)

--- a/tests/test_idpi/test_integ_z2z.py
+++ b/tests/test_idpi/test_integ_z2z.py
@@ -58,7 +58,7 @@ def test_integ_z2z(field, k_max, operator, fx_op, data_dir, fieldextra):
     # compare numerical results
     assert_allclose(
         f_bar_ref,
-        f_bar,
+        f_bar.squeeze(),  # fx has no eps nor step dims
         rtol=1e-6,
         atol=1e-5,
         equal_nan=True,

--- a/tests/test_idpi/test_integ_z2z.py
+++ b/tests/test_idpi/test_integ_z2z.py
@@ -13,7 +13,7 @@ from idpi.operators.vertical_reduction import integrate_k
     "operator,fx_op",
     [("integral", "integ"), ("normed_integral", "norm_integ")],
 )
-def test_integ_z2z(field, k_max, operator, fx_op, data_dir, fieldextra, grib_defs):
+def test_integ_z2z(field, k_max, operator, fx_op, data_dir, fieldextra):
     # modes
     mode = "z2z"
 
@@ -26,9 +26,10 @@ def test_integ_z2z(field, k_max, operator, fx_op, data_dir, fieldextra, grib_def
     cdatafile = data_dir / "lfff00000000c.ch"
 
     # load input data set
-    ds = {}
-    grib_decoder.load_data(ds, [field], datafile, chunk_size=None)
-    grib_decoder.load_data(ds, ["HHL"], cdatafile, chunk_size=None)
+    ds = grib_decoder.load_cosmo_data(
+        [field, "HHL"],
+        [datafile, cdatafile],
+    )
     hhl = ds["HHL"]
     hfl = destagger(hhl, "generalVertical")
     # ATTENTION: attributes are lost in destagger operation

--- a/tests/test_idpi/test_intpl_hk2p.py
+++ b/tests/test_idpi/test_intpl_hk2p.py
@@ -44,11 +44,5 @@ def test_intpl_hk2p(mode, fx_mode, rtol, data_dir, fieldextra):
         voper_lev=fx_voper_lev,
     )
 
-    h_ref = (
-        fx_ds["HEIGHT"]
-        .rename({"x_1": "x", "y_1": "y", "z_1": "isobaricInPa", "epsd_1": "number"})
-        .squeeze()
-    )
-
     # compare numerical results
-    assert_allclose(h_ref, hpl, rtol=rtol, atol=0, equal_nan=True)
+    assert_allclose(fx_ds["HEIGHT"], hpl, rtol=rtol, atol=0, equal_nan=True)

--- a/tests/test_idpi/test_intpl_hk2p.py
+++ b/tests/test_idpi/test_intpl_hk2p.py
@@ -16,7 +16,7 @@ from idpi.operators.vertical_interpolation import interpolate_k2p
         ("linear_in_lnp", "lin_lnp", 1e-5),
     ],
 )
-def test_intpl_hk2p(mode, fx_mode, rtol, data_dir, fieldextra, grib_defs):
+def test_intpl_hk2p(mode, fx_mode, rtol, data_dir, fieldextra):
     # define target coordinates
     tc_values = [300.0, 700.0, 900.0, 1100.0]
     fx_voper_lev = ",".join(str(int(v)) for v in tc_values)
@@ -27,9 +27,10 @@ def test_intpl_hk2p(mode, fx_mode, rtol, data_dir, fieldextra, grib_defs):
     cdatafile = data_dir / "lfff00000000c.ch"
 
     # load input data set
-    ds = {}
-    grib_decoder.load_data(ds, ["P"], datafile, chunk_size=None)
-    grib_decoder.load_data(ds, ["HHL"], cdatafile, chunk_size=None)
+    ds = grib_decoder.load_cosmo_data(
+        ["P", "HHL"],
+        [datafile, cdatafile],
+    )
     hhl = ds["HHL"]
     hfl = destagger(hhl, "generalVertical")
     # ATTENTION: attributes are lost in destagger operation

--- a/tests/test_idpi/test_intpl_k2p.py
+++ b/tests/test_idpi/test_intpl_k2p.py
@@ -35,11 +35,6 @@ def test_intpl_k2p(mode, fx_mode, atol, rtol, data_dir, fieldextra):
     t = interpolate_k2p(ds["T"], mode, ds["P"], tc_values, tc_units)
 
     fx_ds = fieldextra("intpl_k2p", mode=fx_mode, voper_lev=fx_voper_lev)
-    t_ref = (
-        fx_ds["T"]
-        .rename({"x_1": "x", "y_1": "y", "z_1": "isobaricInPa", "epsd_1": "number"})
-        .squeeze()
-    )
 
     # compare numerical results
-    assert_allclose(t_ref, t, rtol=rtol, atol=atol, equal_nan=True)
+    assert_allclose(fx_ds["T"], t, rtol=rtol, atol=atol, equal_nan=True)

--- a/tests/test_idpi/test_intpl_k2p.py
+++ b/tests/test_idpi/test_intpl_k2p.py
@@ -15,7 +15,7 @@ from idpi.operators.vertical_interpolation import interpolate_k2p
         ("linear_in_lnp", "lin_lnp", 1e-5, 1e-6),
     ],
 )
-def test_intpl_k2p(mode, fx_mode, atol, rtol, data_dir, fieldextra, grib_defs):
+def test_intpl_k2p(mode, fx_mode, atol, rtol, data_dir, fieldextra):
     # define target coordinates
     tc_values = [40.0, 500.0, 600.0, 700.0, 800.0, 900.0, 1100.0]
     fx_voper_lev = ",".join(str(int(v)) for v in tc_values)
@@ -25,8 +25,11 @@ def test_intpl_k2p(mode, fx_mode, atol, rtol, data_dir, fieldextra, grib_defs):
     datafile = data_dir / "lfff00000000.ch"
 
     # load input data set
-    ds = {}
-    grib_decoder.load_data(ds, ["T", "P"], datafile, chunk_size=None)
+    ds = grib_decoder.load_cosmo_data(
+        ["P", "T"],
+        [datafile],
+        ref_param="P",
+    )
 
     # call interpolation operator
     t = interpolate_k2p(ds["T"], mode, ds["P"], tc_values, tc_units)

--- a/tests/test_idpi/test_intpl_k2theta.py
+++ b/tests/test_idpi/test_intpl_k2theta.py
@@ -11,7 +11,7 @@ from idpi.operators.vertical_interpolation import interpolate_k2theta
 
 # @pytest.mark.parametrize("mode", ["high_fold", "low_fold", "undef_fold"])
 @pytest.mark.parametrize("mode", ["high_fold", "low_fold"])
-def test_intpl_k2theta(mode, data_dir, fieldextra, grib_defs):
+def test_intpl_k2theta(mode, data_dir, fieldextra):
     # define target coordinates
     tc_values = [280.0, 290.0, 310.0, 315.0, 320.0, 325.0, 330.0, 335.0]
     fx_voper_lev = ",".join(str(int(v)) for v in tc_values)
@@ -22,9 +22,10 @@ def test_intpl_k2theta(mode, data_dir, fieldextra, grib_defs):
     cdatafile = data_dir / "lfff00000000c.ch"
 
     # load input data set
-    ds = {}
-    grib_decoder.load_data(ds, ["T", "P"], datafile, chunk_size=None)
-    grib_decoder.load_data(ds, ["HHL"], cdatafile, chunk_size=None)
+    ds = grib_decoder.load_cosmo_data(
+        ["P", "T", "HHL"],
+        [datafile, cdatafile],
+    )
 
     theta = ftheta(ds["P"], ds["T"])
     hfl = destagger(ds["HHL"], "generalVertical")

--- a/tests/test_idpi/test_intpl_k2theta.py
+++ b/tests/test_idpi/test_intpl_k2theta.py
@@ -39,11 +39,6 @@ def test_intpl_k2theta(mode, data_dir, fieldextra):
         voper_lev=fx_voper_lev,
         voper_lev_units=tc_units,
     )
-    t_ref = (
-        fx_ds["T"]
-        .rename({"x_1": "x", "y_1": "y", "z_1": "theta", "epsd_1": "number"})
-        .squeeze()
-    )
 
     # compare numerical results
-    assert_allclose(t_ref, t, rtol=1e-4, atol=1e-4, equal_nan=True)
+    assert_allclose(fx_ds["T"], t, rtol=1e-4, atol=1e-4, equal_nan=True)

--- a/tests/test_idpi/test_minmax_z2z.py
+++ b/tests/test_idpi/test_minmax_z2z.py
@@ -55,13 +55,9 @@ def test_minmax_z2z(operator, fx_op, field, layer, data_dir, fieldextra):
         ktop=k_top,
     )
 
-    f_minmax_ref = (
-        fx_ds[field].rename({"x_1": "x", "y_1": "y", "epsd_1": "number"}).squeeze()
-    )
-
     # compare numerical results
     assert_allclose(
-        f_minmax_ref,
+        fx_ds[field],
         f_minmax,
         rtol=1e-6,
         atol=1e-5,

--- a/tests/test_idpi/test_minmax_z2z.py
+++ b/tests/test_idpi/test_minmax_z2z.py
@@ -10,7 +10,7 @@ from idpi.operators.vertical_reduction import minmax_k
 
 @pytest.mark.parametrize("operator,fx_op", [("maximum", "max"), ("minimum", "min")])
 @pytest.mark.parametrize("field,layer", [("T", "full"), ("W", "half")])
-def test_minmax_z2z(operator, fx_op, field, layer, data_dir, fieldextra, grib_defs):
+def test_minmax_z2z(operator, fx_op, field, layer, data_dir, fieldextra):
     # modes
     mode = "z2z"
 
@@ -23,9 +23,10 @@ def test_minmax_z2z(operator, fx_op, field, layer, data_dir, fieldextra, grib_de
     cdatafile = data_dir / "lfff00000000c.ch"
 
     # load input data set
-    ds = {}
-    grib_decoder.load_data(ds, field, datafile, chunk_size=None)
-    grib_decoder.load_data(ds, ["HHL"], cdatafile, chunk_size=None)
+    ds = grib_decoder.load_cosmo_data(
+        [field, "HHL"],
+        [datafile, cdatafile],
+    )
 
     if layer == "half":
         height = ds["HHL"]

--- a/tests/test_idpi/test_minmax_z2z.py
+++ b/tests/test_idpi/test_minmax_z2z.py
@@ -57,7 +57,7 @@ def test_minmax_z2z(operator, fx_op, field, layer, data_dir, fieldextra):
 
     # compare numerical results
     assert_allclose(
-        fx_ds[field],
+        fx_ds[field].isel(z_1=0),
         f_minmax,
         rtol=1e-6,
         atol=1e-5,

--- a/tests/test_idpi/test_ninjo_k2th.py
+++ b/tests/test_idpi/test_ninjo_k2th.py
@@ -28,38 +28,37 @@ def test_ninjo_k2th(data_dir, fieldextra):
     )
 
     fs_ds = fieldextra("ninjo_k2th")
-    expected = fs_ds.rename({"x_1": "x", "y_1": "y", "z_2": "theta"})
 
     assert_allclose(
+        fs_ds["POT_VORTIC_MEAN"],
         observed_mean,
-        expected["POT_VORTIC_MEAN"].squeeze(drop=True),
         atol=1e-6,
     )
 
     assert_allclose(
+        fs_ds["POT_VORTIC_AT_THETA"],
         observed_at_theta["pot_vortic"],
-        expected["POT_VORTIC_AT_THETA"].squeeze(drop=True),
         atol=1e-9,
         rtol=1e-5,
     )
 
     assert_allclose(
+        fs_ds["P"],
         observed_at_theta["p"],
-        expected["P"].squeeze(drop=True),
         atol=1e-3,
         rtol=1e-4,
     )
 
     assert_allclose(
+        fs_ds["U"],
         observed_at_theta["u"],
-        expected["U"].squeeze(drop=True),
         atol=1e-9,
         rtol=1e-5,
     )
 
     assert_allclose(
+        fs_ds["V"],
         observed_at_theta["v"],
-        expected["V"].squeeze(drop=True),
         atol=5e-4,
         rtol=1e-4,
     )

--- a/tests/test_idpi/test_ninjo_k2th.py
+++ b/tests/test_idpi/test_ninjo_k2th.py
@@ -6,15 +6,14 @@ import idpi.products.ninjo_k2th as ninjo
 from idpi import grib_decoder
 
 
-def test_product2(data_dir, fieldextra, grib_defs):
+def test_ninjo_k2th(data_dir, fieldextra):
     datafile = data_dir / "lfff00000000.ch"
     cdatafile = data_dir / "lfff00000000c.ch"
 
-    ds = {}
-    grib_decoder.load_data(
-        ds, ["U", "V", "W", "P", "T", "QV", "QC", "QI"], datafile, chunk_size=None
+    ds = grib_decoder.load_cosmo_data(
+        ["U", "V", "W", "P", "T", "QV", "QC", "QI", "HHL"],
+        [datafile, cdatafile],
     )
-    grib_decoder.load_data(ds, ["HHL", "HSURF"], cdatafile, chunk_size=None)
 
     observed_mean, observed_at_theta = ninjo.ninjo_k2th(
         ds["U"],

--- a/tests/test_idpi/test_ninjo_k2th.py
+++ b/tests/test_idpi/test_ninjo_k2th.py
@@ -30,7 +30,7 @@ def test_ninjo_k2th(data_dir, fieldextra):
     fs_ds = fieldextra("ninjo_k2th")
 
     assert_allclose(
-        fs_ds["POT_VORTIC_MEAN"],
+        fs_ds["POT_VORTIC_MEAN"].isel(z_1=0),
         observed_mean,
         atol=1e-6,
     )

--- a/tests/test_idpi/test_potvortic.py
+++ b/tests/test_idpi/test_potvortic.py
@@ -10,21 +10,21 @@ from idpi.operators.theta import ftheta
 from idpi.operators.total_diff import TotalDiff
 
 
-def test_pv(data_dir, fieldextra, grib_defs):
+def test_pv(data_dir, fieldextra):
     datafile = data_dir / "lfff00000000.ch"
     cdatafile = data_dir / "lfff00000000c.ch"
 
-    ds = {}
-    grib_decoder.load_data(
-        ds, ["U", "V", "W", "P", "T", "QV", "QC", "QI"], datafile, chunk_size=None
+    ds = grib_decoder.load_cosmo_data(
+        ["U", "V", "W", "P", "T", "QV", "QC", "QI", "HHL"],
+        [datafile, cdatafile],
     )
-    grib_decoder.load_data(ds, ["HHL", "HSURF"], cdatafile, chunk_size=None)
 
     theta = ftheta(ds["P"], ds["T"])
     rho_tot = f_rho_tot(ds["T"], ds["P"], ds["QV"], ds["QC"], ds["QI"])
 
-    dlon = ds["HHL"].attrs["GRIB_iDirectionIncrementInDegrees"]
-    dlat = ds["HHL"].attrs["GRIB_jDirectionIncrementInDegrees"]
+    geo = ds["HHL"].attrs["geography"]
+    dlon = geo["iDirectionIncrementInDegrees"]
+    dlat = geo["jDirectionIncrementInDegrees"]
     deg2rad = np.pi / 180
 
     total_diff = TotalDiff(dlon * deg2rad, dlat * deg2rad, ds["HHL"])

--- a/tests/test_idpi/test_potvortic.py
+++ b/tests/test_idpi/test_potvortic.py
@@ -32,13 +32,10 @@ def test_pv(data_dir, fieldextra):
     observed = pv.fpotvortic(ds["U"], ds["V"], ds["W"], theta, rho_tot, total_diff)
 
     fs_ds = fieldextra("POT_VORTIC")
-    expected = fs_ds.rename(
-        {"x_1": "x", "y_1": "y", "z_1": "generalVerticalLayer"}
-    ).squeeze(drop=True)
 
     assert_allclose(
+        fs_ds["POT_VORTIC"],
         observed,
-        expected["POT_VORTIC"],
         rtol=1e-4,
         atol=1e-8,
     )

--- a/tests/test_idpi/test_theta.py
+++ b/tests/test_idpi/test_theta.py
@@ -6,11 +6,14 @@ import idpi.operators.theta as mtheta
 from idpi import grib_decoder
 
 
-def test_theta(data_dir, fieldextra, grib_defs):
+def test_theta(data_dir, fieldextra):
     datafile = data_dir / "lfff00000000.ch"
 
-    ds = {}
-    grib_decoder.load_data(ds, ["P", "T"], datafile, chunk_size=None)
+    ds = grib_decoder.load_cosmo_data(
+        ["P", "T"],
+        [datafile],
+        ref_param="P",
+    )
 
     theta = mtheta.ftheta(ds["P"], ds["T"])
 

--- a/tests/test_idpi/test_theta.py
+++ b/tests/test_idpi/test_theta.py
@@ -17,6 +17,6 @@ def test_theta(data_dir, fieldextra):
 
     theta = mtheta.ftheta(ds["P"], ds["T"])
 
-    fs_ds = fieldextra("THETA").squeeze()
+    fs_ds = fieldextra("THETA")
 
     assert_allclose(fs_ds["THETA"], theta, rtol=1e-6)

--- a/tests/test_idpi/test_thetav.py
+++ b/tests/test_idpi/test_thetav.py
@@ -6,11 +6,14 @@ import idpi.operators.thetav as mthetav
 from idpi import grib_decoder
 
 
-def test_thetav(data_dir, fieldextra, grib_defs):
+def test_thetav(data_dir, fieldextra):
     datafile = data_dir / "lfff00000000.ch"
 
-    ds = {}
-    grib_decoder.load_data(ds, ["P", "T", "QV"], datafile, chunk_size=None)
+    ds = grib_decoder.load_cosmo_data(
+        ["P", "T", "QV"],
+        [datafile],
+        ref_param="P",
+    )
 
     thetav = mthetav.fthetav(ds["P"], ds["T"], ds["QV"])
 

--- a/tests/test_idpi/test_thetav.py
+++ b/tests/test_idpi/test_thetav.py
@@ -17,6 +17,6 @@ def test_thetav(data_dir, fieldextra):
 
     thetav = mthetav.fthetav(ds["P"], ds["T"], ds["QV"])
 
-    fs_ds = fieldextra("THETAV").squeeze()
+    fs_ds = fieldextra("THETAV")
 
     assert_allclose(fs_ds["THETA_V"], thetav, rtol=1e-6)

--- a/tests/test_idpi/test_total_diff.py
+++ b/tests/test_idpi/test_total_diff.py
@@ -19,14 +19,14 @@ def test_total_diff(data_dir):
 
     deg2rad = np.pi / 180
 
-    hhl = ds["HHL"].values
+    hhl = ds["HHL"].squeeze().values
     geo = ds["HHL"].attrs["geography"]
     dlon = geo["iDirectionIncrementInDegrees"] * deg2rad
     dlat = geo["jDirectionIncrementInDegrees"] * deg2rad
 
     inv_dlon = 1 / dlon
     inv_dlat = 1 / dlat
-    hhlp = np.pad(np.squeeze(hhl), ((0, 0), (1, 1), (1, 1)), constant_values=np.nan)
+    hhlp = np.pad(hhl, ((0, 0), (1, 1), (1, 1)), constant_values=np.nan)
 
     sqrtg_r_s = 1 / (hhl[:-1] - hhl[1:])
     dzeta_dlam = (
@@ -48,7 +48,7 @@ def test_total_diff(data_dir):
         )
     )
 
-    total_diff = TotalDiff(dlon, dlat, ds["HHL"])
+    total_diff = TotalDiff(dlon, dlat, ds["HHL"].squeeze())
 
     assert_allclose(total_diff.sqrtg_r_s.values, sqrtg_r_s)
     assert_allclose(total_diff.dzeta_dlam.values, dzeta_dlam, rtol=1e-6)
@@ -59,12 +59,13 @@ def test_total_diff(data_dir):
     ds = grib_decoder.load_cosmo_data(["P", "T"], [datafile], ref_param="P")
     theta = ftheta(ds["P"], ds["T"])
 
-    tp = np.pad(theta, 1, mode="edge")
-    dt_dx = 0.5 * (tp[1:-1, 1:-1, 2:] - tp[1:-1, 1:-1, :-2])
-    dt_dy = 0.5 * (tp[1:-1, 2:, 1:-1] - tp[1:-1, :-2, 1:-1])
-    dt_dz = 0.5 * (tp[2:, 1:-1, 1:-1] - tp[:-2, 1:-1, 1:-1])
-    dt_dz[0] *= 2
-    dt_dz[-1] *= 2
+    padding = [(0,0)] * 2 + [(1, 1)] * 3
+    tp = np.pad(theta, padding, mode="edge")
+    dt_dx = 0.5 * (tp[..., 1:-1, 1:-1, 2:] - tp[..., 1:-1, 1:-1, :-2])
+    dt_dy = 0.5 * (tp[..., 1:-1, 2:, 1:-1] - tp[..., 1:-1, :-2, 1:-1])
+    dt_dz = 0.5 * (tp[..., 2:, 1:-1, 1:-1] - tp[..., :-2, 1:-1, 1:-1])
+    dt_dz[..., 0, :, :] *= 2
+    dt_dz[..., -1, :, :] *= 2
 
     dt_dlam = dt_dx / dlon + dzeta_dlam * dt_dz
     dt_dphi = dt_dy / dlat + dzeta_dphi * dt_dz

--- a/tests/test_idpi/test_total_diff.py
+++ b/tests/test_idpi/test_total_diff.py
@@ -9,17 +9,20 @@ from idpi.operators.theta import ftheta
 from idpi.operators.total_diff import TotalDiff
 
 
-def test_total_diff(data_dir, grib_defs):
+def test_total_diff(data_dir):
     cdatafile = data_dir / "lfff00000000c.ch"
 
-    ds = {}
-    grib_decoder.load_data(ds, ["HHL"], cdatafile, chunk_size=None)
+    ds = grib_decoder.load_cosmo_data(
+        ["HHL"],
+        [cdatafile],
+    )
 
     deg2rad = np.pi / 180
 
     hhl = ds["HHL"].values
-    dlon = ds["HHL"].attrs["GRIB_iDirectionIncrementInDegrees"] * deg2rad
-    dlat = ds["HHL"].attrs["GRIB_jDirectionIncrementInDegrees"] * deg2rad
+    geo = ds["HHL"].attrs["geography"]
+    dlon = geo["iDirectionIncrementInDegrees"] * deg2rad
+    dlat = geo["jDirectionIncrementInDegrees"] * deg2rad
 
     inv_dlon = 1 / dlon
     inv_dlat = 1 / dlat
@@ -53,7 +56,7 @@ def test_total_diff(data_dir, grib_defs):
 
     datafile = data_dir / "lfff00000000.ch"
 
-    grib_decoder.load_data(ds, ["P", "T"], datafile, chunk_size=None)
+    ds = grib_decoder.load_cosmo_data(["P", "T"], [datafile], ref_param="P")
     theta = ftheta(ds["P"], ds["T"])
 
     tp = np.pad(theta, 1, mode="edge")

--- a/tests/test_idpi/test_total_diff.py
+++ b/tests/test_idpi/test_total_diff.py
@@ -59,7 +59,7 @@ def test_total_diff(data_dir):
     ds = grib_decoder.load_cosmo_data(["P", "T"], [datafile], ref_param="P")
     theta = ftheta(ds["P"], ds["T"])
 
-    padding = [(0,0)] * 2 + [(1, 1)] * 3
+    padding = [(0, 0)] * 2 + [(1, 1)] * 3
     tp = np.pad(theta, padding, mode="edge")
     dt_dx = 0.5 * (tp[..., 1:-1, 1:-1, 2:] - tp[..., 1:-1, 1:-1, :-2])
     dt_dy = 0.5 * (tp[..., 1:-1, 2:, 1:-1] - tp[..., 1:-1, :-2, 1:-1])

--- a/tests/test_idpi/test_total_diff.py
+++ b/tests/test_idpi/test_total_diff.py
@@ -26,7 +26,7 @@ def test_total_diff(data_dir):
 
     inv_dlon = 1 / dlon
     inv_dlat = 1 / dlat
-    hhlp = np.pad(hhl, ((0, 0), (1, 1), (1, 1)), constant_values=np.nan)
+    hhlp = np.pad(np.squeeze(hhl), ((0, 0), (1, 1), (1, 1)), constant_values=np.nan)
 
     sqrtg_r_s = 1 / (hhl[:-1] - hhl[1:])
     dzeta_dlam = (


### PR DESCRIPTION
## Purpose

Use the `earthkit.data` module.

Note that metadata has changed but it's not an implementation of the proposal for the staggering information. That would be the subject of another PR.

## Code changes:

- The vertical coordinate is dropped but the type of level is used as the vertical dimension. This is done to limit the side effects in the rest of the code.
- The signature of `grib_decoder.load_data` is changed to return a dict rather than mutate the argument.
- A context manager is provided to mutate the grib definitions path. Note that this is *not* thread safe at the moment.
- One of the fields must be indicated as a reference for the horizontal coordinates. All fields are labelled as being defined on those coordinates regardless of staggering. This shortcoming will be addressed in a follow up PR.

## Requirements changes:

- Add earthkit-data
- Remove cfgrib
- Remove netcdf (not a direct dependency)
- Add xarray (is a direct dependency)
