### PR TITLE
Add hzerocl extrapolate option

### DIFF
--- a/src/idpi/operators/hzerocl.py
+++ b/src/idpi/operators/hzerocl.py
@@ -2,26 +2,37 @@
 
 This is done without extrapolation below model orography.
 """
+# Standard library
+from typing import cast
+
 # Third-party
+import numpy as np
 import xarray as xr
 
 # First-party
 from idpi.operators.destagger import destagger
 
 
-def fhzerocl(t: xr.DataArray, hhl: xr.DataArray) -> xr.DataArray:
+def fhzerocl(
+    t: xr.DataArray, hhl: xr.DataArray, extrapolate: bool = False
+) -> xr.DataArray:
     """Height of the zero deg C isotherm in m amsl.
 
     The algorithm searches from the top of the atmosphere downwards.
-    No extrapolation below the earth's surface is done.
 
-    Args:
-        t (xarray.DataArray): air temperature in K
-        hhl (xarray.DataArray): heights of the interfaces between
-            vertical layers in m amsl
+    Parameters
+    ----------
+    t : xr.DataArray
+        Air temperature in K.
+    hhl : xr.DataArray
+        Heights of the interfaces between vertical layers in m amsl.
+    extrapolate : bool
+        Allow the extrapolation of the search below the lowest model layer.
 
-    Returns:
-        xarray.DataArray: height of the zero deg C isotherm in m amsl
+    Returns
+    -------
+    xr.DataArray
+        Height of the zero deg C isotherm in m amsl.
 
     """
     # Physical constants
@@ -34,13 +45,23 @@ def fhzerocl(t: xr.DataArray, hhl: xr.DataArray) -> xr.DataArray:
 
     # 3d field with values of height for those levels where temperature
     # is > 0 and it was < 0 on the level below. Otherwise values are NaN.
-    height2 = hfl.where((t >= t0) & (tkm1 < t0))
+    height0 = hfl.where((t >= t0) & (tkm1 < t0))
 
     # The previous condition can be satisfied on multiple levels.
     # Take the k indices of the maximum height value where the condition is satisfied
-    maxind: xr.DataArray = height2.fillna(-1).argmax(dim="z")  # type: ignore
+    maxind = cast(xr.DataArray, height0.fillna(-1).argmax(dim="z"))
+
+    if extrapolate:
+        # The full column is below freezing
+        below_ground = (t < t0).all("z")
+        # Temperature is increasing with decreasing altitude
+        positive_dt = t[{"z": -1}] - t[{"z": -2}] > 1e-10
+        # Allow t0 to be outside of the [height1, height2] range
+        cond = np.logical_and(below_ground, positive_dt)
+        maxind = maxind.where(~cond, -1)
+
     # Compute the 2D fields with height values where T is > 0 and < 0 on level below
-    height2 = height2[{"z": maxind}]
+    height2 = hfl[{"z": maxind}]
     # Compute the 2D fields with height values where T is < 0 and > 0 on level above
     height1 = hfl[{"z": maxind - 1}]
     # The height level where T == t0 must be between [height1, height2]
@@ -49,4 +70,4 @@ def fhzerocl(t: xr.DataArray, hhl: xr.DataArray) -> xr.DataArray:
 
     hzerocl = height1 + (height2 - height1) * (t0 - t1) / (t2 - t1)
 
-    return hzerocl
+    return hzerocl.where(hzerocl > 0)

--- a/src/idpi/operators/hzerocl.py
+++ b/src/idpi/operators/hzerocl.py
@@ -17,6 +17,9 @@ def fhzerocl(
     """Height of the zero deg C isotherm in m amsl.
 
     The algorithm searches from the top of the atmosphere downwards.
+    When extrapolation is enabled, the search may extend past the lowest
+    layers of the model by means of a linear model. The resulting height
+    may be below the surface of the earth.
 
     Parameters
     ----------

--- a/src/idpi/operators/hzerocl.py
+++ b/src/idpi/operators/hzerocl.py
@@ -1,5 +1,5 @@
-"""Algorithm for computation of height of zero degree isotherm.
-"""
+"""Algorithm for computation of height of zero degree isotherm."""
+
 # Standard library
 from typing import cast
 

--- a/src/idpi/operators/hzerocl.py
+++ b/src/idpi/operators/hzerocl.py
@@ -1,6 +1,4 @@
 """Algorithm for computation of height of zero degree isotherm.
-
-This is done without extrapolation below model orography.
 """
 # Standard library
 from typing import cast
@@ -26,8 +24,9 @@ def fhzerocl(
         Air temperature in K.
     hhl : xr.DataArray
         Heights of the interfaces between vertical layers in m amsl.
-    extrapolate : bool
+    extrapolate : bool, optional
         Allow the extrapolation of the search below the lowest model layer.
+        Defaults to False.
 
     Returns
     -------

--- a/tests/test_idpi/fieldextra_templates/test_hzerocl.nl
+++ b/tests/test_idpi/fieldextra_templates/test_hzerocl.nl
@@ -48,6 +48,7 @@
   tstart=0, tstop=0, tincr=1
   out_file="{{ file.output }}"
   out_type="NETCDF"
+  out_mode_h0cl_extrapolate = {{ h0cl_extrapolate }}
 /
 &Process in_field="HEIGHT", use_tag="hhl_c1e", tag="HFL", level_class="k_full", levmin=1, levmax=80 /
 &Process in_field="HSURF" /
@@ -55,6 +56,7 @@
 &Process
   in_file="{{ file.inputi }}"
   out_file="{{ file.output }}", out_type="NETCDF"
+  out_mode_h0cl_extrapolate = {{ h0cl_extrapolate }}
   tstart=0, tstop=0, tincr=1
 /
 &Process in_field="T", levmin=1, levmax=80 /

--- a/tests/test_idpi/test_hzerocl.py
+++ b/tests/test_idpi/test_hzerocl.py
@@ -1,4 +1,5 @@
 # Third-party
+import pytest
 from numpy.testing import assert_allclose
 
 # First-party
@@ -6,7 +7,8 @@ from idpi import grib_decoder
 from idpi.operators.hzerocl import fhzerocl
 
 
-def test_hzerocl(data_dir, fieldextra):
+@pytest.mark.parametrize("extrapolate", [True, False])
+def test_hzerocl(data_dir, fieldextra, extrapolate):
     datafile = data_dir / "lfff00000000.ch"
     cdatafile = data_dir / "lfff00000000c.ch"
 
@@ -15,14 +17,17 @@ def test_hzerocl(data_dir, fieldextra):
         [datafile, cdatafile],
     )
 
-    hzerocl = fhzerocl(ds["T"], ds["HHL"])
+    hzerocl = fhzerocl(ds["T"], ds["HHL"], extrapolate)
 
-    fs_ds = fieldextra("hzerocl")
+    fs_ds = fieldextra(
+        "hzerocl",
+        h0cl_extrapolate=".true." if extrapolate else ".false.",
+    )
 
     assert_allclose(
         fs_ds["HZEROCL"],
         hzerocl,
-        rtol=1e-6,
+        rtol=5e-6,
         atol=1e-5,
         equal_nan=True,
     )


### PR DESCRIPTION
## Purpose

Add the extrapolate below ground option to the zero degree C isotherm height computation.

## Code changes:

- Add flag `extrapolate` to `fhzerocl` operator. When set to True, the algorithm extrapolates the temperature values in the last 2 model layers down to the zero degree intercept.


