### PR TITLE
activate D107 for docstrings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -158,7 +158,7 @@ ignore = [
     # "D104", # Missing docstring in public package
     "D105", # Missing docstring in magic method
     # "D105", # Missing docstring in public nested class
-    # "D107", # Missing docstring in __init__
+    "D107", # Missing docstring in __init__
     "D203", # Blank line required before class docstring
     "D213", # Multi-line docstring summary should start at the second line
     # "D405", # Section name should be properly capitalized


### PR DESCRIPTION
## Purpose

Activate D107 for enforcing documentation of __init__
since according to PEP 257, __init__ is a public function that should be documented. 
https://stackoverflow.com/questions/37019744/is-there-a-consensus-on-what-should-be-documented-in-the-class-and-init-docs
