### PR TITLE
Update dependencies in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,9 @@ dependencies = [
     "click",
     "earthkit-data",
     "eccodes",
+    "pydantic",
     "pyyaml",
+    "rasterio",
     "numpy",
     "xarray",
 ]


### PR DESCRIPTION
## Purpose

pydantic and rasterio are direct dependencies and should be declared as such.
