### PR TITLE
Add run_products function

### DIFF
--- a/src/idpi/product.py
+++ b/src/idpi/product.py
@@ -2,21 +2,22 @@
 # Standard library
 import dataclasses as dc
 from abc import ABCMeta, abstractmethod
+from collections import Counter
 from typing import NamedTuple
 
 # Local
-from . import tasking
+from . import data_source, grib_decoder, tasking
 
 
 class Request(NamedTuple):
     param: str
-    levtype: str | None = None
+    levtype: str = "ml"
     levelist: tuple[int, ...] | None = None
 
 
 @dc.dataclass
 class ProductDescriptor:
-    input_fields: list[Request]
+    input_fields: dict[str, Request]
 
 
 class Product(metaclass=ABCMeta):
@@ -24,7 +25,7 @@ class Product(metaclass=ABCMeta):
 
     def __init__(
         self,
-        input_fields: list[Request],
+        input_fields: dict[str, Request],
         delay_entire_product: bool = False,
     ):
         self._desc = ProductDescriptor(input_fields=input_fields)
@@ -43,3 +44,45 @@ class Product(metaclass=ABCMeta):
     @property
     def descriptor(self):
         return self._desc
+
+
+def _merge_requests(
+    products: list[Product],
+) -> tuple[dict[str, Request], dict[str, list[str]]]:
+    req_labels: dict[Request, set[str]] = {}
+    for product in products:
+        for name, req in product.descriptor.input_fields.items():
+            name_set = req_labels.setdefault(req, set())
+            name_set.add(name)
+
+    # check for any conflicts in the names
+    cnt = Counter(name for names in req_labels.values() for name in names)
+    conflicts = [name for name, count in cnt.items() if count > 1]
+    if conflicts:
+        raise RuntimeError(f"These names are involved in conflicts: {conflicts}")
+
+    result: dict[str, Request] = {}
+    aliases: dict[str, list[str]] = {}
+    for req, names in req_labels.items():
+        name, *alias = names
+        result[name] = req
+        aliases[name] = alias
+
+    return result, aliases
+
+
+def run_products(
+    products: list[Product],
+    source: data_source.DataSource,
+    ref_param: Request = Request("HHL"),
+):
+    reqs, aliases = _merge_requests(products)
+
+    reader = grib_decoder.GribReader(source, ref_param=ref_param._asdict())
+    ds = reader.load({key: req._asdict() for key, req in reqs.items()})
+    for name, alias in aliases.items():
+        ds.update({a: ds[name] for a in alias})
+
+    results = [product(ds) for product in products]
+
+    return tasking.compute(*results)

--- a/tests/test_idpi/test_product.py
+++ b/tests/test_idpi/test_product.py
@@ -1,0 +1,85 @@
+from unittest import mock
+
+import pytest
+
+from idpi import product, data_source
+
+
+class ProductA(product.Product):
+    def __init__(self, mock_run):
+        input_fields = {
+            "U": product.Request("U"),
+            "V": product.Request("V"),
+            "T_f": product.Request("T"),  # aliased
+        }
+        super().__init__(input_fields=input_fields, delay_entire_product=False)
+        self.mock_run = mock_run
+
+    def _run(self, ds):
+        self.mock_run(ds)
+
+
+class ProductB(product.Product):
+    def __init__(self, mock_run):
+        input_fields = {
+            "P": product.Request("P"),
+            "T": product.Request("T"),
+        }
+        super().__init__(input_fields=input_fields, delay_entire_product=False)
+        self.mock_run = mock_run
+
+    def _run(self, ds):
+        self.mock_run(ds)
+
+
+@mock.patch.object(product.grib_decoder, "GribReader", autospec=True)
+def test_merge(mock_reader_cls):
+    m = mock.Mock()
+    product_a = ProductA(m.a)
+    product_b = ProductB(m.b)
+
+    requested = []
+
+    def store(req):
+        requested.append(req)
+
+    m.field.side_effect = store
+
+    def load(reqs):
+        return {key: m.field(value) for key, value in reqs.items()}
+
+    mock_reader_cls.return_value = m.reader
+    m.reader.load.side_effect = load
+
+    source = data_source.DataSource()
+    product.run_products([product_a, product_b], source)
+
+    # requests have been merged
+    observed = sorted(requested, key=lambda req: req["param"])
+    expected = [product.Request(p)._asdict() for p in sorted("UVPT")]
+    assert observed == expected
+
+    # all necessary fields are present
+    [ds_a] = m.a.call_args.args
+    [ds_b] = m.b.call_args.args
+    assert ds_a.keys() >= product_a.descriptor.input_fields.keys()
+    assert ds_b.keys() >= product_b.descriptor.input_fields.keys()
+
+
+class ProductC(product.Product):
+    def __init__(self, mock_run):
+        input_fields = {
+            "T": product.Request("T", "pl"),
+        }
+        super().__init__(input_fields=input_fields, delay_entire_product=False)
+        self.mock_run = mock_run
+
+    def _run(self, ds):
+        self.mock_run(ds)
+
+
+def test_raises_on_conflict():
+    m = mock.Mock()
+    source = data_source.DataSource()
+    with pytest.raises(RuntimeError):
+        product.run_products([ProductA(m.a), ProductB(m.b), ProductC(m.c)], source)

--- a/tests/test_idpi/test_product.py
+++ b/tests/test_idpi/test_product.py
@@ -1,8 +1,11 @@
+# Standard library
 from unittest import mock
 
+# Third-party
 import pytest
 
-from idpi import product, data_source
+# First-party
+from idpi import data_source, product
 
 
 class ProductA(product.Product):


### PR DESCRIPTION
## Purpose

Added a function that manages the running of multiple products together. Notably, the functions makes sure that redundant requests are only submitted once to the data source.

## Code changes

- Added the `idpi.product.run_products` function.