### PR TITLE
Support multiple params in mars requests

### DIFF
--- a/src/idpi/mars.py
+++ b/src/idpi/mars.py
@@ -104,12 +104,9 @@ class Request:
     def _staggered(self):
         mapping = _load_mapping()
         if isinstance(self.param, Iterable) and not isinstance(self.param, str):
-            first, *others = (
+            return any(
                 mapping[param]["cosmo"].get("vertStag", False) for param in self.param
             )
-            if not all(first == other for other in others):
-                raise ValueError("Not all fields have the same staggering.")
-            return first
         return mapping[self.param]["cosmo"].get("vertStag", False)
 
     def to_fdb(self) -> dict[str, typing.Any]:

--- a/src/idpi/mars.py
+++ b/src/idpi/mars.py
@@ -2,6 +2,7 @@
 
 # Standard library
 import dataclasses as dc
+import typing
 from collections.abc import Iterable
 from enum import Enum
 from functools import cache
@@ -111,7 +112,7 @@ class Request:
             return first
         return mapping[self.param]["cosmo"].get("vertStag", False)
 
-    def to_fdb(self):
+    def to_fdb(self) -> dict[str, typing.Any]:
         if self.date is None or self.time is None:
             raise RuntimeError("date and time are required fields for FDB.")
 
@@ -119,9 +120,10 @@ class Request:
             n_lvl = N_LVL[self.model]
             if self._staggered():
                 n_lvl += 1
-            levelist = tuple(range(1, n_lvl + 1))
+            levelist: int | tuple[int, ...] | None = tuple(range(1, n_lvl + 1))
         else:
             levelist = self.levelist
 
         obj = dc.replace(self, levelist=levelist)
-        return obj.dump() | {"param": self._param_id()}  # type: ignore
+        out = typing.cast(dict[str, typing.Any], obj.dump())
+        return out | {"param": self._param_id()}

--- a/src/idpi/mars.py
+++ b/src/idpi/mars.py
@@ -68,7 +68,7 @@ N_LVL = {
     config=pydantic.ConfigDict(use_enum_values=True),
 )
 class Request:
-    param: str | int | tuple[str, ...] | tuple[int, ...]
+    param: str | tuple[str, ...]
     date: str | None = None  # YYYYMMDD
     time: str | None = None  # hhmm
 
@@ -123,5 +123,5 @@ class Request:
         else:
             levelist = self.levelist
 
-        obj = dc.replace(self, param=self._param_id(), levelist=levelist)
-        return obj.dump()
+        obj = dc.replace(self, levelist=levelist)
+        return obj.dump() | {"param": self._param_id()}  # type: ignore

--- a/tests/test_idpi/test_mars.py
+++ b/tests/test_idpi/test_mars.py
@@ -68,6 +68,11 @@ def test_multiple_params(sample):
     assert observed == expected
 
 
-def test_different_staggering():
-    with pytest.raises(ValueError):
-        mars.Request(("U", "V", "W"), date="20200101", time="0000").to_fdb()
+def test_any_staggering(sample):
+    observed = mars.Request(("U", "V", "W"), date="20200101", time="0000").to_fdb()
+    expected = sample | {
+        "param": [500028, 500030, 500032],
+        "levelist": list(range(1, 82)),
+    }
+
+    assert observed == expected

--- a/tests/test_idpi/test_mars.py
+++ b/tests/test_idpi/test_mars.py
@@ -59,3 +59,15 @@ def test_fdb_sfc(sample):
 def test_request_raises():
     with pytest.raises(ValueError):
         mars.Request("U", date="20200101", time="0000", model="undef")
+
+
+def test_multiple_params(sample):
+    observed = mars.Request(("U", "V"), date="20200101", time="0000").to_fdb()
+    expected = sample | {"param": [500028, 500030]}
+
+    assert observed == expected
+
+
+def test_different_staggering():
+    with pytest.raises(ValueError):
+        mars.Request(("U", "V", "W"), date="20200101", time="0000").to_fdb()


### PR DESCRIPTION
## Purpose

The mars request can support multiple parameters however due to the different vertical staggering of some fields, some care needs to be taken when generating the default levelist values.

## Code changes:

- `mars.Request` supports defining multiple parameters
