### PR TITLE
Require at least pydantic 2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "click",
     "earthkit-data",
     "eccodes",
-    "pydantic",
+    "pydantic>=2",
     "pyyaml",
     "rasterio",
     "numpy",


### PR DESCRIPTION
## Purpose

Idpi requires at least pydantic version 2. Otherwise the following error is shown:
```
  File "/opt/conda/lib/python3.10/site-packages/idpi/mars.py", line 91, in dump
    root = pydantic.RootModel(self)
AttributeError: module 'pydantic' has no attribute 'RootModel'
```