### PR TITLE
Write to grib file

### DIFF
--- a/src/idpi/grib_decoder.py
+++ b/src/idpi/grib_decoder.py
@@ -330,6 +330,25 @@ def _get_type_of_level(field):
 
 
 def save(field: xr.DataArray, file_handle: io.BufferedWriter):
+    """Write field to file in GRIB format.
+
+    Parameters
+    ----------
+    field : xarray.DataArray
+        Field to write into the output file.
+    file_handle : io.BufferedWriter
+        File handle for the output file.
+
+    Raises
+    ------
+    ValueError
+        If the field does not have a metadata attribute.
+
+    """
+    if not hasattr(field, "metadata"):
+        msg = "The metadata attribute is required to write to the GRIB format."
+        raise ValueError(msg)
+
     idx = {
         dim: field.coords[key]
         for key in field.dims

--- a/src/idpi/grib_decoder.py
+++ b/src/idpi/grib_decoder.py
@@ -2,11 +2,14 @@
 # Standard library
 import dataclasses as dc
 import datetime as dt
+import io
 import typing
 from collections.abc import Mapping
+from itertools import product
 from pathlib import Path
 
 # Third-party
+import earthkit.data as ekd
 import numpy as np
 import xarray as xr
 
@@ -18,6 +21,7 @@ DIM_MAP = {
     "perturbationNumber": "eps",
     "step": "time",
 }
+INV_DIM_MAP = {v: k for k, v in DIM_MAP.items()}
 VCOORD_TYPE = {
     "generalVertical": ("model_level", -0.5),
     "generalVerticalLayer": ("model_level", 0.0),
@@ -206,6 +210,7 @@ class GribReader:
                 "x": np.round((geo[x0_key] % 360 - x0) / dx, 1),
                 "y": np.round((geo[y0_key] - y0) / dy, 1),
             },
+            "metadata": field.metadata(),
         }
         return metadata
 
@@ -309,3 +314,36 @@ class GribReader:
     ) -> dict[str, xr.DataArray]:
         reqs = {param: param for param in params}
         return self.load(reqs, extract_pv)
+
+
+def _get_type_of_level(field):
+    if field.vcoord_type == "model_level":
+        if field.origin["z"] == 0.0:
+            return "generalVerticalLayer"
+        elif field.origin["z"] == -0.5:
+            return "generalVertical"
+        else:
+            raise ValueError(f"Unsupported field origin in z: {field.origin['z']}")
+    else:
+        mapping = {vc: name for name, (vc, _) in VCOORD_TYPE.items()}
+        return mapping.get(field.vcoord_type, field.vcoord_type)
+
+
+def save(field: xr.DataArray, file_handle: io.BufferedWriter):
+    idx = {
+        dim: field.coords[key]
+        for key in field.dims
+        if (dim := str(key)) not in {"x", "y"}
+    }
+
+    def to_grib(loc: dict[str, xr.DataArray]):
+        result = {INV_DIM_MAP[key]: value.item() for key, value in loc.items()}
+        return result | {"typeOfLevel": _get_type_of_level(field)}
+
+    for idx_slice in product(*idx.values()):
+        loc = {dim: value for dim, value in zip(idx.keys(), idx_slice)}
+        array = field.sel(loc).values
+        metadata = field.metadata.override(to_grib(loc))
+
+        fs = ekd.FieldList.from_numpy(array, metadata)
+        fs.write(file_handle)

--- a/src/idpi/grib_decoder.py
+++ b/src/idpi/grib_decoder.py
@@ -9,7 +9,7 @@ from itertools import product
 from pathlib import Path
 
 # Third-party
-import earthkit.data as ekd
+import earthkit.data as ekd  # type: ignore
 import numpy as np
 import xarray as xr
 

--- a/tests/test_idpi/test_grib_decoder.py
+++ b/tests/test_idpi/test_grib_decoder.py
@@ -19,8 +19,8 @@ def test_save(data_dir, tmp_path):
     reader = grib_decoder.GribReader.from_files([outfile], ref_param="HHL")
     ds_new = reader.load_fieldnames(["HHL"])
 
-    ds["HHL"].attrs.pop("metadata")
-    ds_new["HHL"].attrs.pop("metadata")
+    ds["HHL"].attrs.pop("message")
+    ds_new["HHL"].attrs.pop("message")
 
     xr.testing.assert_identical(ds["HHL"], ds_new["HHL"])
 
@@ -40,7 +40,7 @@ def test_save_field(data_dir, tmp_path, param):
     reader = grib_decoder.GribReader.from_files([outfile, cdatafile], ref_param="HHL")
     ds_new = reader.load_fieldnames([param])
 
-    ds[param].attrs.pop("metadata")
-    ds_new[param].attrs.pop("metadata")
+    ds[param].attrs.pop("message")
+    ds_new[param].attrs.pop("message")
 
     xr.testing.assert_identical(ds[param], ds_new[param])

--- a/tests/test_idpi/test_grib_decoder.py
+++ b/tests/test_idpi/test_grib_decoder.py
@@ -1,0 +1,24 @@
+# Third-party
+import xarray as xr
+
+# First-party
+from idpi import grib_decoder
+
+
+def test_save(data_dir, tmp_path):
+    datafile = data_dir / "lfff00000000c.ch"
+
+    reader = grib_decoder.GribReader.from_files([datafile], ref_param="HHL")
+    ds = reader.load_fieldnames(["HHL"])
+
+    outfile = tmp_path / "output.grib"
+    with outfile.open("wb") as f:
+        grib_decoder.save(ds["HHL"], f)
+
+    reader = grib_decoder.GribReader.from_files([outfile], ref_param="HHL")
+    ds_new = reader.load_fieldnames(["HHL"])
+
+    ds["HHL"].attrs.pop("metadata")
+    ds_new["HHL"].attrs.pop("metadata")
+
+    xr.testing.assert_identical(ds["HHL"], ds_new["HHL"])


### PR DESCRIPTION
## Purpose

Provide the ability to write xarray.DataArray objects back to the GRIB format.

## Code changes

- Add `save` function to `grib_decoder` module

Notes:
- most operators currently do not update the metadata 
- the earthkit data metadata object is added to the DataArray attributes and contain one entire GRIB message