### PR TITLE
Regrid cli

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,6 +14,7 @@ add these directories to sys.path here. If the directory is relative to the
 documentation root, use os.path.abspath to make it absolute, like shown here.
 
 """
+
 # Standard library
 import os
 import sys

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ documentation = "https://github.io/MeteoSwiss-APN/icon-data-processing-incubator
 
 [project.scripts]
 # Format: <command> = "<package>.<module>:<function>"
-# icon-data-processing-incubator = "idpi.cli:main"
+icon-data-processing-incubator = "idpi.cli:main"
 
 [tool.setuptools.packages.find]
 namespaces = true

--- a/requirements/requirements.yaml
+++ b/requirements/requirements.yaml
@@ -6,7 +6,7 @@ dependencies:
   - pip>=22.3
   # runtime
   - click>=8.1
-  - eccodes>=2.25.0
+  - eccodes>=2.25.0,<2.34
   - earthkit-data>=0.2.0
   - jinja2>=3.1.1
   - numpy>=1.23

--- a/src/idpi/__init__.py
+++ b/src/idpi/__init__.py
@@ -1,4 +1,5 @@
 """Top-level package for Icon Data Processing Incubator."""
+
 # Standard library
 import importlib.metadata
 

--- a/src/idpi/cli.py
+++ b/src/idpi/cli.py
@@ -73,9 +73,15 @@ def handle_vector_fields(ds):
             u = destagger.destagger(u, "x")
         if v.origin["y"] != 0.0:
             v = destagger.destagger(v, "y")
-        u_g, v_g = gis.vref_rot2geolatlon(u, v)
-        ds[u_name] = u_g
-        ds[v_name] = v_g
+        if u.vref == "native" and v.vref == "native":
+            u_g, v_g = gis.vref_rot2geolatlon(u, v)
+            ds[u_name] = u_g
+            ds[v_name] = v_g
+        elif u.vref == "geo" and v.vref == "geo":
+            continue
+        else:
+            msg = "Differing vector references."
+            raise RuntimeError(msg)
 
 
 @main.command("regrid")

--- a/src/idpi/cli.py
+++ b/src/idpi/cli.py
@@ -1,4 +1,5 @@
 """Command line interface of idpi."""
+
 # Standard library
 from importlib.resources import files
 from pathlib import Path

--- a/src/idpi/cli.py
+++ b/src/idpi/cli.py
@@ -120,7 +120,10 @@ def regrid_cmd(
     outfile: Path,
     params: str,
 ):
-    """Regrid the given PARAMS found in INFILE and write to OUTFILE."""
+    """Regrid the given PARAMS found in INFILE and write to OUTFILE.
+
+    PARAMS is a comma separated list of short names following the cosmo convention.
+    """
     resampling_arg = RESAMPLING[resampling]
     crs_str = regrid.CRS_ALIASES.get(crs, crs)
 
@@ -140,8 +143,8 @@ def regrid_cmd(
             src = regrid.RegularGrid.from_field(field)
             dst = src.to_crs(crs_str)
 
-            click.echo(f"Regriding field {name} to {dst}")
+            click.echo(f"Regridding field {name} to {dst}")
             field_out = regrid.regrid(field, dst, resampling_arg)
 
-            click.echo(f"Writing grib fields to {outfile}")
+            click.echo(f"Writing GRIB fields to {outfile}")
             grib_decoder.save(field_out, fout)

--- a/src/idpi/cli.py
+++ b/src/idpi/cli.py
@@ -1,9 +1,13 @@
 """Command line interface of idpi."""
+from pathlib import Path
+
 # Third-party
 import click
 
 # Local
 from . import __version__
+from . import grib_decoder
+from .operators import regrid
 
 
 def print_version(ctx, _, value: bool) -> None:
@@ -13,6 +17,7 @@ def print_version(ctx, _, value: bool) -> None:
         ctx.exit(0)
 
 
+@click.group()
 @click.option(
     "--version",
     "-V",
@@ -21,7 +26,35 @@ def print_version(ctx, _, value: bool) -> None:
     expose_value=False,
     callback=print_version,
 )
-@click.group()
 def main() -> None:
     """Console script for test_cli_project."""
     print("CLI for IDPI")
+
+
+RESAMPLING = {
+    "nearest": regrid.Resampling.nearest,
+    "bilinear": regrid.Resampling.bilinear,
+    "cubic": regrid.Resampling.cubic,
+}
+
+
+@main.command("regrid")
+@click.option("--crs", type=click.Choice(["geolatlon"]), default="geolatlon")
+@click.option("--resampling", type=click.Choice(list(RESAMPLING.keys())), default="nearest")
+@click.argument("infile")
+@click.argument("outfile")
+@click.argument("params")
+def regrid_cmd(crs: str, resampling: str, infile: Path, outfile: Path, params: str):
+    resampling_arg = RESAMPLING[resampling]
+    crs_str = regrid.CRS_ALIASES.get(crs, crs)
+    
+    reader = grib_decoder.GribReader.from_files([infile])
+    ds = reader.load_fieldnames(params.split(","))
+
+    with outfile.open("wb") as fout:
+        for field in ds.values():
+            src = regrid.RegularGrid.from_field(field)
+            dst = src.to_crs(crs_str)
+
+            field_out = regrid.regrid(field, dst, resampling_arg)
+            grib_decoder.save(field_out, fout)

--- a/src/idpi/data/field_mappings.yml
+++ b/src/idpi/data/field_mappings.yml
@@ -55,12 +55,14 @@ U:
     paramId: 131
   cosmo:
     paramId: 500028
+    vComponent: V
 V:
   ifs:
     name: v
     paramId: 132
   cosmo:
     paramId: 500030
+    uComponent: U
 W:
   cosmo:
     paramId: 500032
@@ -77,12 +79,14 @@ U_10M:
     paramId: 165
   cosmo:
     paramId: 500027
+    vComponent: V_10M
 V_10M:
   ifs:
     name: 10v
     paramId: 166
   cosmo:
     paramId: 500029
+    uComponent: U_10M
 T_2M:
   ifs:
     name: 2t

--- a/src/idpi/data_cache.py
+++ b/src/idpi/data_cache.py
@@ -5,7 +5,6 @@ suitable for reading by fieldextra.
 
 """
 
-
 # Standard library
 import dataclasses as dc
 from itertools import product

--- a/src/idpi/grib_decoder.py
+++ b/src/idpi/grib_decoder.py
@@ -1,4 +1,5 @@
 """Decoder for grib data."""
+
 # Standard library
 import dataclasses as dc
 import datetime as dt

--- a/src/idpi/grib_decoder.py
+++ b/src/idpi/grib_decoder.py
@@ -193,6 +193,7 @@ class GribReader:
         metadata: dict[str, typing.Any] = field.metadata(
             namespace=["geography", "parameter"]
         )
+        # https://codes.ecmwf.int/grib/format/grib2/ctables/3/3/
         [vref_flag] = get_code_flag(field.metadata("resolutionAndComponentFlags"), [5])
         level_type: str = field.metadata("typeOfLevel")
         vcoord_type, zshift = VCOORD_TYPE.get(level_type, (level_type, 0.0))
@@ -414,7 +415,7 @@ def set_code_flag(indices: Sequence[int]) -> int:
     -------
     int
         Code flag with bits set at the given indices.
-    
+
     """
     value = 0
     for index in indices:

--- a/src/idpi/operators/atmo.py
+++ b/src/idpi/operators/atmo.py
@@ -1,4 +1,5 @@
 """Atmospheric thermodynamic functions."""
+
 # Third-party
 import numpy as np
 

--- a/src/idpi/operators/brn.py
+++ b/src/idpi/operators/brn.py
@@ -1,4 +1,5 @@
 """algorithm for BRN operator."""
+
 # Third-party
 import numpy as np
 import xarray as xr

--- a/src/idpi/operators/destagger.py
+++ b/src/idpi/operators/destagger.py
@@ -1,4 +1,5 @@
 """algorithm for destaggering a field."""
+
 # Standard library
 from typing import Any, Literal
 
@@ -6,6 +7,7 @@ from typing import Any, Literal
 import numpy as np
 import xarray as xr
 
+# Local
 from .. import metadata
 
 ExtendArg = Literal["left", "right", "both"] | None

--- a/src/idpi/operators/destagger.py
+++ b/src/idpi/operators/destagger.py
@@ -1,10 +1,12 @@
 """algorithm for destaggering a field."""
 # Standard library
-from typing import Literal
+from typing import Any, Literal
 
 # Third-party
 import numpy as np
 import xarray as xr
+
+from .. import metadata
 
 ExtendArg = Literal["left", "right", "both"] | None
 
@@ -70,6 +72,28 @@ def interpolate_midpoint(array: np.ndarray, extend: ExtendArg = None) -> np.ndar
     return f_map[extend](array)
 
 
+def _update_grid(field: xr.DataArray, dim: Literal["x", "y"]) -> dict[str, Any]:
+    geo = field.geography
+    if dim == "x":
+        lon_min = np.round(geo["longitudeOfFirstGridPointInDegrees"] * 1e6)
+        lon_max = np.round(geo["longitudeOfLastGridPointInDegrees"] * 1e6)
+        dx = np.round(geo["iDirectionIncrementInDegrees"] * 1e6)
+        return metadata.override(
+            field.message,
+            longitudeOfFirstGridPoint=lon_min - dx / 2,
+            longitudeOfLastGridPoint=lon_max - dx / 2,
+        )
+    if dim == "y":
+        lat_min = np.round(geo["latitudeOfFirstGridPointInDegrees"] * 1e6)
+        lat_max = np.round(geo["latitudeOfLastGridPointInDegrees"] * 1e6)
+        dy = np.round(geo["jDirectionIncrementInDegrees"] * 1e6)
+        return metadata.override(
+            field.message,
+            latitudeOfFirstGridPoint=lat_min - dy / 2,
+            latitudeOfLastGridPoint=lat_max - dy / 2,
+        )
+
+
 def destagger(
     field: xr.DataArray,
     dim: Literal["x", "y", "z"],
@@ -114,7 +138,7 @@ def destagger(
                 keep_attrs=True,
             )
             .transpose(*dims)
-            .assign_attrs(origin=field.origin | {dim: 0.0})
+            .assign_attrs(origin=field.origin | {dim: 0.0}, **_update_grid(field, dim))
         )
     elif dim == "z":
         if field.origin[dim] != -0.5:

--- a/src/idpi/operators/gis.py
+++ b/src/idpi/operators/gis.py
@@ -217,7 +217,8 @@ def vref_rot2geolatlon(
 
     grid = get_grid(u.geography)
     lon, lat = rot2geolatlon(grid)
-    return _vref_rot2geolatlon(u, v, lon, lat, grid)
+    u_g, v_g = _vref_rot2geolatlon(u, v, lon, lat, grid)
+    return xr.DataArray(u_g, attrs=u.attrs), xr.DataArray(v_g, attrs=v.attrs)
 
 
 def _vref_rot2geolatlon(

--- a/src/idpi/operators/omega_slope.py
+++ b/src/idpi/operators/omega_slope.py
@@ -1,4 +1,5 @@
 """algorithm for computing omega_slope."""
+
 # Third-party
 import numpy as np
 import xarray as xr

--- a/src/idpi/operators/regrid.py
+++ b/src/idpi/operators/regrid.py
@@ -210,7 +210,7 @@ def _get_metadata(grid: RegularGrid):
             "longitudeOfFirstGridPoint": _udeg(grid.xmin),
             "resolutionAndComponentFlags": resolution_components_flags,
             "latitudeOfLastGridPoint": _udeg(grid.ymax),
-            "longitudeOfLastGridPoint": _udeg(grid.ymax),
+            "longitudeOfLastGridPoint": _udeg(grid.xmax),
             "iDirectionIncrement": _udeg(grid.dx),
             "jDirectionIncrement": _udeg(grid.dy),
             "scanningMode": scanning_mode,

--- a/src/idpi/operators/regrid.py
+++ b/src/idpi/operators/regrid.py
@@ -12,6 +12,7 @@ from rasterio.crs import CRS
 
 # Local
 from .. import metadata
+from ..grib_decoder import set_code_flag
 
 Resampling: typing.TypeAlias = warp.Resampling
 
@@ -181,16 +182,6 @@ class RegularGrid:
         )
 
 
-def _code_flag(indices: list[int]):
-    value = 0
-    for index in indices:
-        if not 1 <= index <= 8:
-            raise ValueError("index must in range [1,8]")
-        shift = 8 - index
-        value |= 1 << shift
-    return value
-
-
 def _udeg(value):
     return int(round(value * 1e6))
 
@@ -198,9 +189,9 @@ def _udeg(value):
 def _get_metadata(grid: RegularGrid):
     # geolatlon
     if grid.crs.to_epsg() == 4326:
-        scanning_mode = _code_flag([2])  # positive y
+        scanning_mode = set_code_flag([2])  # positive y
         # i, j direction increments given
-        resolution_components_flags = _code_flag([3, 4])
+        resolution_components_flags = set_code_flag([3, 4])
         return {
             "numberOfDataPoints": grid.nx * grid.ny,
             "sourceOfGridDefinition": 0,  # defined by template number

--- a/src/idpi/operators/regrid.py
+++ b/src/idpi/operators/regrid.py
@@ -10,6 +10,7 @@ import xarray as xr
 from rasterio import transform, warp
 from rasterio.crs import CRS
 
+# Local
 from .. import metadata
 
 Resampling: typing.TypeAlias = warp.Resampling

--- a/src/idpi/operators/regrid.py
+++ b/src/idpi/operators/regrid.py
@@ -200,7 +200,6 @@ def _get_metadata(grid: RegularGrid):
         scanning_mode = _code_flag([2])  # positive y
         # i, j direction increments given
         resolution_components_flags = _code_flag([3, 4])
-        # TODO: track vector field reference system
         return {
             "numberOfDataPoints": grid.nx * grid.ny,
             "sourceOfGridDefinition": 0,  # defined by template number

--- a/src/idpi/operators/regrid.py
+++ b/src/idpi/operators/regrid.py
@@ -189,6 +189,7 @@ def _udeg(value):
 
 
 def _get_metadata(grid: RegularGrid):
+    # geolatlon
     if grid.crs.to_epsg() == 4326:
         scanning_mode = 0
         _set_bit(scanning_mode, 6)  # positive y

--- a/src/idpi/operators/regrid.py
+++ b/src/idpi/operators/regrid.py
@@ -189,8 +189,11 @@ def _udeg(value):
 def _get_metadata(grid: RegularGrid):
     # geolatlon
     if grid.crs.to_epsg() == 4326:
+        # https://codes.ecmwf.int/grib/format/grib2/ctables/3/4/
         scanning_mode = set_code_flag([2])  # positive y
         # i, j direction increments given
+        # bit 5 left unset since the target grid is geolatlon
+        # both values are equivalent in this case
         resolution_components_flags = set_code_flag([3, 4])
         return {
             "numberOfDataPoints": grid.nx * grid.ny,

--- a/src/idpi/operators/regrid.py
+++ b/src/idpi/operators/regrid.py
@@ -180,8 +180,14 @@ class RegularGrid:
         )
 
 
-def _set_bit(value, index):
-    return value | (1 << index)
+def _code_flag(indices: list[int]):
+    value = 0
+    for index in indices:
+        if not 1 <= index <= 8:
+            raise ValueError("index must in range [1,8]")
+        shift = 8 - index
+        value |= 1 << shift
+    return value
 
 
 def _udeg(value):
@@ -191,11 +197,9 @@ def _udeg(value):
 def _get_metadata(grid: RegularGrid):
     # geolatlon
     if grid.crs.to_epsg() == 4326:
-        scanning_mode = 0
-        _set_bit(scanning_mode, 6)  # positive y
-        resolution_components_flags = 0
-        _set_bit(resolution_components_flags, 5)  # i direction incr given
-        _set_bit(resolution_components_flags, 4)  # j direction incr given
+        scanning_mode = _code_flag([2])  # positive y
+        # i, j direction increments given
+        resolution_components_flags = _code_flag([3, 4])
         # TODO: track vector field reference system
         return {
             "numberOfDataPoints": grid.nx * grid.ny,

--- a/src/idpi/operators/relhum.py
+++ b/src/idpi/operators/relhum.py
@@ -1,4 +1,5 @@
 """Relative humidity operators."""
+
 # Standard library
 from typing import Literal
 

--- a/src/idpi/operators/support_operators.py
+++ b/src/idpi/operators/support_operators.py
@@ -1,6 +1,5 @@
 """Algorithms to support operations on a field."""
 
-
 # Standard library
 import dataclasses as dc
 from typing import Any, Literal, Optional, Sequence

--- a/src/idpi/operators/theta.py
+++ b/src/idpi/operators/theta.py
@@ -1,4 +1,5 @@
 """algorithm to compute the potential temperature theta in K."""
+
 # Third-party
 import xarray as xr
 

--- a/src/idpi/operators/time_operators.py
+++ b/src/idpi/operators/time_operators.py
@@ -1,4 +1,5 @@
 """Various time operators."""
+
 # Third-party
 import numpy as np
 import xarray as xr

--- a/src/idpi/operators/total_diff.py
+++ b/src/idpi/operators/total_diff.py
@@ -1,4 +1,5 @@
 """Finite difference stencils on xarray dataarrays."""
+
 # Standard library
 import dataclasses as dc
 

--- a/src/idpi/product.py
+++ b/src/idpi/product.py
@@ -1,4 +1,5 @@
 """Product base classes."""
+
 # Standard library
 import dataclasses as dc
 from abc import ABCMeta, abstractmethod

--- a/src/idpi/tasking.py
+++ b/src/idpi/tasking.py
@@ -1,4 +1,5 @@
 """functionality for tasking and parallel computing."""
+
 # Third-party
 import dask
 

--- a/tests/test_idpi/conftest.py
+++ b/tests/test_idpi/conftest.py
@@ -1,4 +1,5 @@
 """Test configuration."""
+
 # Standard library
 import os
 import subprocess

--- a/tests/test_idpi/test_grib_decoder.py
+++ b/tests/test_idpi/test_grib_decoder.py
@@ -6,6 +6,7 @@ import xarray as xr
 from idpi import grib_decoder
 
 
+@pytest.mark.xfail(reason="eccodes writes the values with 16 bit instead of 24 bit")
 def test_save(data_dir, tmp_path):
     datafile = data_dir / "COSMO-1E/1h/const/000/lfff00000000c"
 


### PR DESCRIPTION
## Purpose

Add CLI for the regrid operator and update the metadata for writing back to GRIB. Limited to the geolatlon target in this PR. Other target CRS will leave the metadata untouched.

## Code changes:

- The `regrid.regrid` operator updates the metadata if the target CRS is `geolatlon` (WGS 84, epsg: 4326)
- The CLI now includes a subcommand for the regrid operator


