### PR TITLE
Metadata grid

### DIFF
--- a/src/idpi/grib_decoder.py
+++ b/src/idpi/grib_decoder.py
@@ -138,7 +138,7 @@ class GribReader:
         metadata |= {
             "vref": "native" if vref_flag else "geo",
             "vcoord_type": vcoord_type,
-            "zshift": zshift,
+            "origin": {"z": zshift},
             "message": field.message(),
         }
         return metadata

--- a/src/idpi/grib_decoder.py
+++ b/src/idpi/grib_decoder.py
@@ -1,13 +1,13 @@
 """Decoder for grib data."""
 
 # Standard library
-import dataclasses as dc
 import datetime as dt
 import io
 import typing
 from collections.abc import Mapping, Sequence
 from itertools import product
 from pathlib import Path
+from warnings import warn
 
 # Third-party
 import earthkit.data as ekd  # type: ignore
@@ -76,34 +76,11 @@ def _extract_pv(pv):
     }
 
 
-@dc.dataclass
-class Grid:
-    """Coordinates of the reference grid.
-
-    Attributes
-    ----------
-    lon: xr.DataArray
-        2d array with longitude of geographical coordinates
-    lat: xr.DataArray
-        2d array with latitude of geographical coordinates
-    lon_first_grid_point: float
-        longitude of first grid point in rotated lat-lon CRS
-    lat_first_grid_point: float
-        latitude of first grid point in rotated lat-lon CRS
-
-    """
-
-    lon: xr.DataArray
-    lat: xr.DataArray
-    lon_first_grid_point: float
-    lat_first_grid_point: float
-
-
 class GribReader:
     def __init__(
         self,
         source: data_source.DataSource,
-        ref_param: Request = "HHL",
+        ref_param: Request | None = None,
     ):
         """Initialize a grib reader from a data source.
 
@@ -121,10 +98,11 @@ class GribReader:
 
         """
         self.data_source = source
-        self._grid = self.load_grid_reference(ref_param)
+        if ref_param is not None:
+            warn("GribReader: ref_param is deprecated.")
 
     @classmethod
-    def from_files(cls, datafiles: list[Path], ref_param: Request = "HHL"):
+    def from_files(cls, datafiles: list[Path], ref_param: Request | None = None):
         """Initialize a grib reader from a list of grib files.
 
         Parameters
@@ -142,47 +120,6 @@ class GribReader:
         """
         return cls(data_source.DataSource([str(p) for p in datafiles]), ref_param)
 
-    def load_grid_reference(self, ref_param: Request) -> Grid:
-        """Construct a grid from a reference parameter.
-
-        Parameters
-        ----------
-        ref_param : Request
-            name of parameter used to construct a reference grid.
-
-        Raises
-        ------
-        ValueError
-            if ref_param is not found in the input dataset
-
-        Returns
-        -------
-        Grid
-            reference grid
-
-        """
-        fs = self.data_source.retrieve(ref_param)
-        it = iter(fs)
-        field = next(it, None)
-        if field is None:
-            msg = f"reference field, {ref_param=} not found in data source."
-            raise RuntimeError(msg)
-        lonlat_dict = {
-            geo_dim: xr.DataArray(dims=("y", "x"), data=values)
-            for geo_dim, values in field.to_latlon().items()
-        }
-
-        grid = Grid(
-            lonlat_dict["lon"],
-            lonlat_dict["lat"],
-            *field.metadata(
-                "longitudeOfFirstGridPointInDegrees",
-                "latitudeOfFirstGridPointInDegrees",
-            ),
-        )
-
-        return grid
-
     def _load_pv(self, pv_param: Request):
         fs = self.data_source.retrieve(pv_param)
 
@@ -198,22 +135,10 @@ class GribReader:
         level_type: str = field.metadata("typeOfLevel")
         vcoord_type, zshift = VCOORD_TYPE.get(level_type, (level_type, 0.0))
 
-        x0 = self._grid.lon_first_grid_point % 360
-        y0 = self._grid.lat_first_grid_point
-        geo = metadata["geography"]
-        dx = geo["iDirectionIncrementInDegrees"]
-        dy = geo["jDirectionIncrementInDegrees"]
-        x0_key = "longitudeOfFirstGridPointInDegrees"
-        y0_key = "latitudeOfFirstGridPointInDegrees"
-
         metadata |= {
             "vref": "native" if vref_flag else "geo",
             "vcoord_type": vcoord_type,
-            "origin": {
-                "z": zshift,
-                "x": np.round((geo[x0_key] % 360 - x0) / dx, 1),
-                "y": np.round((geo[y0_key] - y0) / dy, 1),
-            },
+            "zshift": zshift,
             "message": field.message(),
         }
         return metadata
@@ -224,7 +149,7 @@ class GribReader:
     ):
         fs = self.data_source.retrieve(req)
 
-        hcoords = None
+        hcoords: dict[str, xr.DataArray] = {}
         metadata: dict[str, typing.Any] = {}
         time_meta: dict[int, dict] = {}
         dims: tuple[str, ...] | None = None
@@ -249,15 +174,17 @@ class GribReader:
             if not metadata:
                 metadata = self._construct_metadata(field)
 
+            if not hcoords:
+                hcoords = {
+                    dim: xr.DataArray(dims=("y", "x"), data=values)
+                    for dim, values in field.to_latlon().items()
+                }
+
         if not field_map:
             raise RuntimeError(f"requested {req=} not found.")
 
         coords, shape = _gather_coords(field_map, dims)
         tcoords = _gather_tcoords(time_meta)
-        hcoords = {
-            "lon": self._grid.lon,
-            "lat": self._grid.lat,
-        }
 
         array = xr.DataArray(
             np.array([field_map.pop(key) for key in sorted(field_map)]).reshape(shape),

--- a/src/idpi/metadata.py
+++ b/src/idpi/metadata.py
@@ -1,11 +1,14 @@
 """Manage GRIB metadata."""
 
 # Standard library
+import dataclasses as dc
 import io
 import typing
 
 # Third-party
 import earthkit.data as ekd  # type: ignore
+import numpy as np
+import xarray as xr
 from earthkit.data.writers import write  # type: ignore
 
 
@@ -40,3 +43,93 @@ def override(message: bytes, **kwargs: typing.Any) -> dict[str, typing.Any]:
         "geography": md.as_namespace("geography"),
         "parameter": md.as_namespace("parameter"),
     }
+
+
+@dc.dataclass
+class Grid:
+    """Coordinates of the reference grid.
+
+    Attributes
+    ----------
+    lon: xr.DataArray
+        2d array with longitude of geographical coordinates
+    lat: xr.DataArray
+        2d array with latitude of geographical coordinates
+    lon_first_grid_point: float
+        longitude of first grid point in rotated lat-lon CRS
+    lat_first_grid_point: float
+        latitude of first grid point in rotated lat-lon CRS
+
+    """
+
+    lon: xr.DataArray
+    lat: xr.DataArray
+    lon_first_grid_point: float
+    lat_first_grid_point: float
+
+
+def load_grid_reference(message: bytes) -> Grid:
+    """Construct a grid from a reference parameter.
+
+    Parameters
+    ----------
+    message : bytes
+        name of parameter used to construct a reference grid.
+
+    Returns
+    -------
+    Grid
+        reference grid
+
+    """
+    stream = io.BytesIO(message)
+    [grib_field] = ekd.from_source("stream", stream)
+
+    lonlat_dict = {
+        geo_dim: xr.DataArray(dims=("y", "x"), data=values)
+        for geo_dim, values in grib_field.to_latlon().items()
+    }
+
+    return Grid(
+        lonlat_dict["lon"],
+        lonlat_dict["lat"],
+        *grib_field.metadata(
+            "longitudeOfFirstGridPointInDegrees",
+            "latitudeOfFirstGridPointInDegrees",
+        ),
+    )
+
+
+def compute_origin(ref_grid: Grid, field: xr.DataArray) -> dict[str, float]:
+    """
+    """
+    x0 = ref_grid.lon_first_grid_point % 360
+    y0 = ref_grid.lat_first_grid_point
+    geo = field.geography
+    dx = geo["iDirectionIncrementInDegrees"]
+    dy = geo["jDirectionIncrementInDegrees"]
+    x0_key = "longitudeOfFirstGridPointInDegrees"
+    y0_key = "latitudeOfFirstGridPointInDegrees"
+
+    return {
+        "z": field.zshift,
+        "x": np.round((geo[x0_key] % 360 - x0) / dx, 1),
+        "y": np.round((geo[y0_key] - y0) / dy, 1),
+    }
+
+
+def set_origin(ds: dict[str, xr.DataArray], ref_param: str) -> None:
+    """
+
+    Raises
+    ------
+    KeyError
+        if ref_param is not found in the input dataset
+
+    """
+    if ref_param not in ds:
+        raise KeyError(f"ref_param {ref_param} not present in dataset.")
+
+    ref_grid = load_grid_reference(ds[ref_param].message)
+    for field in ds.values():
+        field.attrs["origin"] = compute_origin(ref_grid, field)

--- a/src/idpi/metadata.py
+++ b/src/idpi/metadata.py
@@ -112,13 +112,12 @@ def compute_origin(ref_grid: Grid, field: xr.DataArray) -> dict[str, float]:
     y0_key = "latitudeOfFirstGridPointInDegrees"
 
     return {
-        "z": field.zshift,
         "x": np.round((geo[x0_key] % 360 - x0) / dx, 1),
         "y": np.round((geo[y0_key] - y0) / dy, 1),
     }
 
 
-def set_origin(ds: dict[str, xr.DataArray], ref_param: str) -> None:
+def set_origin_xy(ds: dict[str, xr.DataArray], ref_param: str) -> None:
     """
 
     Raises
@@ -132,4 +131,4 @@ def set_origin(ds: dict[str, xr.DataArray], ref_param: str) -> None:
 
     ref_grid = load_grid_reference(ds[ref_param].message)
     for field in ds.values():
-        field.attrs["origin"] = compute_origin(ref_grid, field)
+        field.attrs["origin"] |= compute_origin(ref_grid, field)

--- a/src/idpi/metadata.py
+++ b/src/idpi/metadata.py
@@ -74,7 +74,7 @@ def load_grid_reference(message: bytes) -> Grid:
     Parameters
     ----------
     message : bytes
-        name of parameter used to construct a reference grid.
+        GRIB message defining the reference grid.
 
     Returns
     -------
@@ -101,7 +101,20 @@ def load_grid_reference(message: bytes) -> Grid:
 
 
 def compute_origin(ref_grid: Grid, field: xr.DataArray) -> dict[str, float]:
-    """
+    """Compute horizontal components of the origin dict.
+
+    Parameters
+    ----------
+    ref_grid : Grid
+        reference grid
+    field : xarray.DataArray
+        field for which to compute the origin
+
+    Returns
+    -------
+    dict[str, float]
+        Horizontal components of the origin
+
     """
     x0 = ref_grid.lon_first_grid_point % 360
     y0 = ref_grid.lat_first_grid_point
@@ -118,12 +131,19 @@ def compute_origin(ref_grid: Grid, field: xr.DataArray) -> dict[str, float]:
 
 
 def set_origin_xy(ds: dict[str, xr.DataArray], ref_param: str) -> None:
-    """
+    """Set horizontal components of the origin attribute.
+
+    Parameters
+    ----------
+    ds : dict[str, xarray.DataArray]
+        Dataset of fields to update.
+    ref_param : str
+        Name of the paramter field to use as a reference. Must be a key of ds.
 
     Raises
     ------
     KeyError
-        if ref_param is not found in the input dataset
+        if the ref_param key is not found in the input dataset
 
     """
     if ref_param not in ds:

--- a/tests/test_idpi/test_brn.py
+++ b/tests/test_idpi/test_brn.py
@@ -4,6 +4,7 @@ from numpy.testing import assert_allclose
 # First-party
 import idpi.operators.brn as mbrn
 from idpi.grib_decoder import GribReader
+from idpi.metadata import set_origin_xy
 
 
 def test_brn(data_dir, fieldextra):
@@ -12,6 +13,7 @@ def test_brn(data_dir, fieldextra):
 
     reader = GribReader.from_files([cdatafile, datafile])
     ds = reader.load_fieldnames(["P", "T", "QV", "U", "V", "HHL", "HSURF"])
+    set_origin_xy(ds, "HHL")
 
     brn = mbrn.fbrn(
         ds["P"], ds["T"], ds["QV"], ds["U"], ds["V"], ds["HHL"], ds["HSURF"]

--- a/tests/test_idpi/test_curl.py
+++ b/tests/test_idpi/test_curl.py
@@ -4,6 +4,7 @@ from xarray.testing import assert_allclose
 
 # First-party
 from idpi.grib_decoder import GribReader
+from idpi.metadata import set_origin_xy
 from idpi.operators import curl
 from idpi.operators.support_operators import get_grid_coords
 from idpi.operators.total_diff import TotalDiff
@@ -15,6 +16,7 @@ def test_curl(data_dir):
 
     reader = GribReader.from_files([cdatafile, datafile])
     ds = reader.load_fieldnames(["U", "V", "W", "HHL"])
+    set_origin_xy(ds, ref_param="HHL")
 
     geo = ds["HHL"].attrs["geography"]
     dlon = geo["iDirectionIncrementInDegrees"]

--- a/tests/test_idpi/test_destagger.py
+++ b/tests/test_idpi/test_destagger.py
@@ -3,6 +3,7 @@ from numpy.testing import assert_allclose
 
 # First-party
 from idpi.grib_decoder import GribReader
+from idpi.metadata import set_origin_xy
 from idpi.operators.destagger import destagger
 
 
@@ -14,6 +15,7 @@ def test_destagger(data_dir, fieldextra):
     ds = reader.load_fieldnames(
         ["U", "V", "HHL"],
     )
+    set_origin_xy(ds, ref_param="HHL")
 
     u = destagger(ds["U"], "x")
     v = destagger(ds["V"], "y")

--- a/tests/test_idpi/test_diff.py
+++ b/tests/test_idpi/test_diff.py
@@ -10,7 +10,7 @@ from idpi.operators.theta import ftheta
 
 def test_masspoint_field(data_dir):
     datafile = data_dir / "COSMO-1E/1h/ml_sl/000/lfff00000000"
-    reader = GribReader.from_files([datafile], ref_param="P")
+    reader = GribReader.from_files([datafile])
 
     ds = reader.load_fieldnames(["P", "T"])
 
@@ -33,7 +33,7 @@ def test_masspoint_field(data_dir):
 
 def test_staggered_field(data_dir):
     datafile = data_dir / "COSMO-1E/1h/ml_sl/000/lfff00000000"
-    reader = GribReader.from_files([datafile], ref_param="W")
+    reader = GribReader.from_files([datafile])
 
     ds = reader.load_fieldnames(["W"])
 

--- a/tests/test_idpi/test_gis.py
+++ b/tests/test_idpi/test_gis.py
@@ -6,6 +6,7 @@ from numpy.testing import assert_allclose
 
 # First-party
 from idpi import grib_decoder
+from idpi.metadata import set_origin_xy
 from idpi.operators import gis
 
 
@@ -43,8 +44,9 @@ def test_geolatlon2swiss(coords):
 
 def test_vref_rot2geolatlon(data_dir, fieldextra):
     datafile = data_dir / "COSMO-1E/1h/ml_sl/000/lfff00000000"
-    reader = grib_decoder.GribReader.from_files([datafile], ref_param="T")
+    reader = grib_decoder.GribReader.from_files([datafile])
     ds = reader.load_fieldnames(["U_10M", "V_10M"])
+    set_origin_xy(ds, ref_param="U_10M")
 
     u_g, v_g = gis.vref_rot2geolatlon(ds["U_10M"], ds["V_10M"])
 

--- a/tests/test_idpi/test_grib_decoder.py
+++ b/tests/test_idpi/test_grib_decoder.py
@@ -31,14 +31,14 @@ def test_save_field(data_dir, tmp_path, param):
     datafile = data_dir / "COSMO-1E/1h/ml_sl/000/lfff00000000"
     cdatafile = data_dir / "COSMO-1E/1h/const/000/lfff00000000c"
 
-    reader = grib_decoder.GribReader.from_files([datafile, cdatafile], ref_param="HHL")
+    reader = grib_decoder.GribReader.from_files([datafile, cdatafile])
     ds = reader.load_fieldnames([param])
 
     outfile = tmp_path / "output.grib"
     with outfile.open("wb") as f:
         grib_decoder.save(ds[param], f)
 
-    reader = grib_decoder.GribReader.from_files([outfile, cdatafile], ref_param="HHL")
+    reader = grib_decoder.GribReader.from_files([outfile, cdatafile])
     ds_new = reader.load_fieldnames([param])
 
     ds[param].attrs.pop("message")

--- a/tests/test_idpi/test_intpl_k2p.py
+++ b/tests/test_idpi/test_intpl_k2p.py
@@ -25,7 +25,7 @@ def test_intpl_k2p(mode, fx_mode, atol, rtol, data_dir, fieldextra):
     datafile = data_dir / "COSMO-1E/1h/ml_sl/000/lfff00000000"
 
     # load input data set
-    reader = GribReader.from_files([datafile], ref_param="P")
+    reader = GribReader.from_files([datafile])
     ds = reader.load_fieldnames(["P", "T"])
 
     # call interpolation operator

--- a/tests/test_idpi/test_ninjo_k2th.py
+++ b/tests/test_idpi/test_ninjo_k2th.py
@@ -4,6 +4,7 @@ from numpy.testing import assert_allclose
 # First-party
 import idpi.products.ninjo_k2th as ninjo
 from idpi.grib_decoder import GribReader
+from idpi.metadata import set_origin_xy
 
 
 def test_ninjo_k2th(data_dir, fieldextra):
@@ -13,6 +14,7 @@ def test_ninjo_k2th(data_dir, fieldextra):
     reader = GribReader.from_files([cdatafile, datafile])
 
     ds = reader.load_fieldnames(["U", "V", "W", "P", "T", "QV", "QC", "QI", "HHL"])
+    set_origin_xy(ds, ref_param="HHL")
     observed_mean, observed_at_theta = ninjo.ninjo_k2th(
         ds["U"],
         ds["V"],

--- a/tests/test_idpi/test_potvortic.py
+++ b/tests/test_idpi/test_potvortic.py
@@ -8,6 +8,7 @@ import idpi.operators.pot_vortic as pv
 from idpi.data_cache import DataCache
 from idpi.data_source import DataSource
 from idpi.grib_decoder import GribReader
+from idpi.metadata import set_origin_xy
 from idpi.operators.rho import f_rho_tot
 from idpi.operators.theta import ftheta
 from idpi.operators.total_diff import TotalDiff
@@ -34,6 +35,7 @@ def data(work_dir, request_template, setup_fdb):
 def test_pv(data, fieldextra):
     reader, cache = data
     ds = reader.load_fieldnames(["U", "V", "W", "P", "T", "QV", "QC", "QI", "HHL"])
+    set_origin_xy(ds, ref_param="HHL")
 
     theta = ftheta(ds["P"], ds["T"])
     rho_tot = f_rho_tot(ds["T"], ds["P"], ds["QV"], ds["QC"], ds["QI"])

--- a/tests/test_idpi/test_relhum.py
+++ b/tests/test_idpi/test_relhum.py
@@ -10,7 +10,7 @@ def test_relhum(data_dir, fieldextra):
     datafile = data_dir / "COSMO-1E/1h/ml_sl/000/lfff00000000"
     cdatafile = data_dir / "COSMO-1E/1h/const/000/lfff00000000c"
 
-    reader = GribReader.from_files([cdatafile, datafile], ref_param="P")
+    reader = GribReader.from_files([cdatafile, datafile])
     ds = reader.load_fieldnames(["P", "T", "QV"])
 
     relhum_arr = relhum(ds["QV"], ds["T"], ds["P"], clipping=True, phase="water")

--- a/tests/test_idpi/test_theta.py
+++ b/tests/test_idpi/test_theta.py
@@ -8,7 +8,7 @@ from idpi.grib_decoder import GribReader
 
 def test_theta(data_dir, fieldextra):
     datafile = data_dir / "COSMO-1E/1h/ml_sl/000/lfff00000000"
-    reader = GribReader.from_files([datafile], ref_param="P")
+    reader = GribReader.from_files([datafile])
 
     ds = reader.load_fieldnames(["P", "T"])
 

--- a/tests/test_idpi/test_thetav.py
+++ b/tests/test_idpi/test_thetav.py
@@ -8,7 +8,7 @@ from idpi.grib_decoder import GribReader
 
 def test_thetav(data_dir, fieldextra):
     datafile = data_dir / "COSMO-1E/1h/ml_sl/000/lfff00000000"
-    reader = GribReader.from_files([datafile], ref_param="P")
+    reader = GribReader.from_files([datafile])
 
     ds = reader.load_fieldnames(["P", "T", "QV"])
     thetav = mthetav.fthetav(ds["P"], ds["T"], ds["QV"])

--- a/tests/test_idpi/test_time_ops.py
+++ b/tests/test_idpi/test_time_ops.py
@@ -17,7 +17,7 @@ def test_delta(data_dir, fieldextra):
     dd, hh = np.divmod(steps, 24)
     datafiles = [data_dir / f"lfff{d:02d}{h:02d}0000" for d, h in zip(dd, hh)]
 
-    reader = GribReader.from_files(datafiles, ref_param="TOT_PREC")
+    reader = GribReader.from_files(datafiles)
     ds = reader.load_fieldnames(["TOT_PREC"])
 
     tot_prec = time_ops.resample(ds["TOT_PREC"], np.timedelta64(3, "h"))

--- a/tests/test_idpi/test_wind.py
+++ b/tests/test_idpi/test_wind.py
@@ -3,6 +3,7 @@ from numpy.testing import assert_allclose
 
 # First-party
 from idpi.grib_decoder import GribReader
+from idpi.metadata import set_origin_xy
 from idpi.operators import wind
 
 
@@ -12,6 +13,7 @@ def test_wind(data_dir, fieldextra):
 
     reader = GribReader.from_files([datafile, cdatafile])
     ds = reader.load_fieldnames(["U_10M", "V_10M"])
+    set_origin_xy(ds, ref_param="U_10M")
 
     u_10m = ds["U_10M"].isel(z=0)
     v_10m = ds["V_10M"].isel(z=0)


### PR DESCRIPTION
## Purpose

Refactor logic that sets the horizontal components of the origin attribute into the metadata module. Loading the reference grid is no longer done during the initialisation of the GribReader instance but can be triggered by a dedicated function. This notably avoids hitting the data source (e.g. FDB) with a request of a single field.

## Code changes:

- Added `metadata.set_origin_xy` function
- Deprecated GribReader ref_param argument