### PR TITLE
Allow to set bits_per_value

### DIFF
--- a/src/idpi/grib_decoder.py
+++ b/src/idpi/grib_decoder.py
@@ -260,7 +260,7 @@ def _get_type_of_level(field):
         return mapping.get(field.vcoord_type, field.vcoord_type)
 
 
-def save(field: xr.DataArray, file_handle: io.BufferedWriter):
+def save(field: xr.DataArray, file_handle: io.BufferedWriter, bits_per_value: int = 16):
     """Write field to file in GRIB format.
 
     Parameters
@@ -269,6 +269,8 @@ def save(field: xr.DataArray, file_handle: io.BufferedWriter):
         Field to write into the output file.
     file_handle : io.BufferedWriter
         File handle for the output file.
+    bits_per_value : int
+        Bits per value encoded in the output file.
 
     Raises
     ------
@@ -299,7 +301,7 @@ def save(field: xr.DataArray, file_handle: io.BufferedWriter):
         metadata = md.override(to_grib(loc))
 
         fs = ekd.FieldList.from_numpy(array, metadata)
-        fs.write(file_handle)
+        fs.write(file_handle, bits_per_value=bits_per_value)
 
 
 def get_code_flag(value: int, indices: Sequence[int]) -> list[bool]:

--- a/tests/test_idpi/test_grib_decoder.py
+++ b/tests/test_idpi/test_grib_decoder.py
@@ -6,18 +6,17 @@ import xarray as xr
 from idpi import grib_decoder
 
 
-@pytest.mark.xfail(reason="eccodes writes the values with 16 bit instead of 24 bit")
 def test_save(data_dir, tmp_path):
     datafile = data_dir / "COSMO-1E/1h/const/000/lfff00000000c"
 
-    reader = grib_decoder.GribReader.from_files([datafile], ref_param="HHL")
+    reader = grib_decoder.GribReader.from_files([datafile])
     ds = reader.load_fieldnames(["HHL"])
 
     outfile = tmp_path / "output.grib"
     with outfile.open("wb") as f:
-        grib_decoder.save(ds["HHL"], f)
+        grib_decoder.save(ds["HHL"], f, bits_per_value=24)
 
-    reader = grib_decoder.GribReader.from_files([outfile], ref_param="HHL")
+    reader = grib_decoder.GribReader.from_files([outfile])
     ds_new = reader.load_fieldnames(["HHL"])
 
     ds["HHL"].attrs.pop("message")


### PR DESCRIPTION
## Purpose

Expose the `bit_per_value` when writing back to grib. This option overrides the value in the GRIB metadata and is set to a default of 16 in the earthkit.data lib. 

## Code changes:

- Added `bits_per_value` option to the `grib_decoder.save` function