### PR TITLE
Refactor grib reader

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,6 +101,7 @@ ignore = [
     "F811", # Allow redefinition of unused name (necessary for typing.overload)
     "I002", # Don't check for isort configuration
     "W503", # Allow line break before binary operator (PEP 8-compatible)
+    "E704", # Allow multiple statements on one line (def)
 ]
 per-file-ignores = [
     "__init__.py: F401", # Allow unused imports

--- a/src/idpi/grib_decoder.py
+++ b/src/idpi/grib_decoder.py
@@ -2,6 +2,7 @@
 
 # Standard library
 import datetime as dt
+import dataclasses as dc
 import io
 import logging
 import typing
@@ -37,39 +38,8 @@ def _is_ensemble(field) -> bool:
         return False
 
 
-def _gather_coords(field_map, dims):
-    coord_values = zip(*field_map)
-    unique = (sorted(set(values)) for values in coord_values)
-    coords = {dim: c for dim, c in zip(dims[:-2], unique)}
-
-    if missing := [
-        combination
-        for combination in product(*coords.values())
-        if combination not in field_map
-    ]:
-        msg = f"Missing combinations: {missing}"
-        logger.exception(msg)
-        raise RuntimeError(msg)
-
-    ny, nx = next(iter(field_map.values())).shape
-    shape = tuple(len(v) for v in coords.values()) + (ny, nx)
-    return coords, shape
-
-
 def _parse_datetime(date, time):
     return dt.datetime.strptime(f"{date}{time:04d}", "%Y%m%d%H%M")
-
-
-def _gather_tcoords(time_meta):
-    time = None
-    valid_time = []
-    for step in sorted(time_meta):
-        tm = time_meta[step]
-        valid_time.append(_parse_datetime(tm["validityDate"], tm["validityTime"]))
-        if time is None:
-            time = _parse_datetime(tm["dataDate"], tm["dataTime"])
-
-    return {"valid_time": ("time", valid_time), "ref_time": time}
 
 
 def _extract_pv(pv):
@@ -80,6 +50,115 @@ def _extract_pv(pv):
         "ak": xr.DataArray(pv[:i], dims="z"),
         "bk": xr.DataArray(pv[i:], dims="z"),
     }
+
+
+@dc.dataclass
+class FieldBuffer:
+    dims: tuple[str, ...] | None = None
+    hcoords: dict[str, xr.DataArray] = dc.field(default_factory=dict)
+    metadata: dict[str, typing.Any] = dc.field(default_factory=dict)
+    time_meta: dict[int, dict] = dc.field(default_factory=dict)
+    values: dict[tuple[int, ...], np.ndarray] = dc.field(default_factory=dict)
+
+    def load(self, field):
+        dim_keys = (
+            ("perturbationNumber", "step", "level")
+            if _is_ensemble(field)
+            else ("step", "level")
+        )
+        key = field.metadata(*dim_keys)
+        logger.debug("Received field for key: %s", key)
+        self.values[key] = field.to_numpy(dtype=np.float32)
+
+        step = key[-2]  # assume all members share the same time steps
+        if step not in self.time_meta:
+            self.time_meta[step] = field.metadata(namespace="time")
+
+        if not self.dims:
+            self.dims = tuple(DIM_MAP[d] for d in dim_keys) + ("y", "x")
+
+        if not self.metadata:
+            self.metadata = {
+                "message": field.message(),
+                **metadata.extract(field.metadata()),
+            }
+
+        if not self.hcoords:
+            self.hcoords = {
+                dim: xr.DataArray(dims=("y", "x"), data=values)
+                for dim, values in field.to_latlon().items()
+            }
+
+    def _gather_coords(self):
+        if self.dims is None:
+            raise RuntimeError
+
+        coord_values = zip(*self.values)
+        unique = (sorted(set(values)) for values in coord_values)
+        coords = {dim: c for dim, c in zip(self.dims[:-2], unique)}
+
+        if missing := [
+            combination
+            for combination in product(*coords.values())
+            if combination not in self.values
+        ]:
+            msg = f"Missing combinations: {missing}"
+            logger.exception(msg)
+            raise RuntimeError(msg)
+
+        ny, nx = next(iter(self.values.values())).shape
+        shape = tuple(len(v) for v in coords.values()) + (ny, nx)
+        return coords, shape
+
+    def _gather_tcoords(self):
+        time = None
+        valid_time = []
+        for step in sorted(self.time_meta):
+            tm = self.time_meta[step]
+            valid_time.append(_parse_datetime(tm["validityDate"], tm["validityTime"]))
+            if time is None:
+                time = _parse_datetime(tm["dataDate"], tm["dataTime"])
+
+        return {"valid_time": ("time", valid_time), "ref_time": time}
+
+    def to_xarray(self):
+        coords, shape = self._gather_coords()
+        tcoords = self._gather_tcoords()
+
+        array = xr.DataArray(
+            np.array([self.values.pop(key) for key in sorted(self.values)]).reshape(
+                shape
+            ),
+            coords=coords | self.hcoords | tcoords,
+            dims=self.dims,
+            attrs=self.metadata,
+        )
+
+        return (
+            array if array.vcoord_type != "surface" else array.squeeze("z", drop=True)
+        )
+
+
+def load(
+    source: data_source.DataSource,
+    request: Request,
+    single_param: bool = False,
+):
+    logger.info("Retrieving request: %s", request)
+    fs = source.retrieve(request)
+
+    buffer_map: dict[str, FieldBuffer] = {}
+
+    for field in fs:
+        name = field.metadata("shortName")
+        buffer = buffer_map.setdefault(name, FieldBuffer())
+        buffer.load(field)
+
+    if single_param:
+        [buffer] = buffer_map.values()
+        return buffer.to_xarray()
+
+    return {name: buffer.to_xarray() for name, buffer in buffer_map.items()}
 
 
 class GribReader:
@@ -132,65 +211,6 @@ class GribReader:
         for field in fs:
             return field.metadata("pv")
 
-    def _load_param(
-        self,
-        req: Request,
-    ):
-        logger.info("Retrieving request: %s", req)
-        fs = self.data_source.retrieve(req)
-
-        hcoords: dict[str, xr.DataArray] = {}
-        metadata_values: dict[str, typing.Any] = {}
-        time_meta: dict[int, dict] = {}
-        dims: tuple[str, ...] | None = None
-        field_map: dict[tuple[int, ...], np.ndarray] = {}
-
-        for field in fs:
-            dim_keys = (
-                ("perturbationNumber", "step", "level")
-                if _is_ensemble(field)
-                else ("step", "level")
-            )
-            key = field.metadata(*dim_keys)
-            logger.debug("Received field for key: %s", key)
-            field_map[key] = field.to_numpy(dtype=np.float32)
-
-            step = key[-2]  # assume all members share the same time steps
-            if step not in time_meta:
-                time_meta[step] = field.metadata(namespace="time")
-
-            if not dims:
-                dims = tuple(DIM_MAP[d] for d in dim_keys) + ("y", "x")
-
-            if not metadata_values:
-                metadata_values = {
-                    "message": field.message(),
-                    **metadata.extract(field.metadata()),
-                }
-
-            if not hcoords:
-                hcoords = {
-                    dim: xr.DataArray(dims=("y", "x"), data=values)
-                    for dim, values in field.to_latlon().items()
-                }
-
-        if not field_map:
-            raise RuntimeError(f"requested {req=} not found.")
-
-        coords, shape = _gather_coords(field_map, dims)
-        tcoords = _gather_tcoords(time_meta)
-
-        array = xr.DataArray(
-            np.array([field_map.pop(key) for key in sorted(field_map)]).reshape(shape),
-            coords=coords | hcoords | tcoords,
-            dims=dims,
-            attrs=metadata_values,
-        )
-
-        return (
-            array if array.vcoord_type != "surface" else array.squeeze("z", drop=True)
-        )
-
     def load(
         self,
         requests: Mapping[str, Request],
@@ -218,7 +238,7 @@ class GribReader:
 
         """
         result = {
-            name: tasking.delayed(self._load_param)(req)
+            name: tasking.delayed(load)(self.data_source, req, single_param=True)
             for name, req in requests.items()
         }
 

--- a/src/idpi/grib_decoder.py
+++ b/src/idpi/grib_decoder.py
@@ -1,8 +1,8 @@
 """Decoder for grib data."""
 
 # Standard library
-import datetime as dt
 import dataclasses as dc
+import datetime as dt
 import io
 import logging
 import typing

--- a/src/idpi/grib_decoder.py
+++ b/src/idpi/grib_decoder.py
@@ -91,7 +91,7 @@ class _FieldBuffer:
 
     def _gather_coords(self):
         if self.dims is None:
-            raise RuntimeError
+            raise RuntimeError("No dims.")
 
         coord_values = zip(*self.values)
         unique = (sorted(set(values)) for values in coord_values)
@@ -122,6 +122,9 @@ class _FieldBuffer:
         return {"valid_time": ("time", valid_time), "ref_time": time}
 
     def to_xarray(self) -> xr.DataArray:
+        if not self.values:
+            raise RuntimeError("No values.")
+
         coords, shape = self._gather_coords()
         tcoords = self._gather_tcoords()
 
@@ -161,6 +164,26 @@ def load_single_param(
     source: data_source.DataSource,
     request: Request,
 ) -> xr.DataArray:
+    """Request data from a data source for a single parameter.
+
+    Parameters
+    ----------
+    source : data_source.DataSource
+        Source to request the data from.
+    request : str | tuple[str, str] | dict[str, Any]
+        Request for data from the source in the mars language.
+
+    Raises
+    ------
+    RuntimeError
+        when data is missing.
+
+    Returns
+    -------
+    xarray.DataArray
+        A data array of the requested field.
+
+    """
     buffer_map = _load_buffer_map(source, request)
     [buffer] = buffer_map.values()
     return buffer.to_xarray()
@@ -170,6 +193,26 @@ def load(
     source: data_source.DataSource,
     request: Request,
 ) -> dict[str, xr.DataArray]:
+    """Request data from a data source.
+
+    Parameters
+    ----------
+    source : data_source.DataSource
+        Source to request the data from.
+    request : str | tuple[str, str] | dict[str, Any]
+        Request for data from the source in the mars language.
+
+    Raises
+    ------
+    RuntimeError
+        when data is missing.
+
+    Returns
+    -------
+    dict[str, xarray.DataArray]
+        A mapping of shortName to data arrays of the requested fields.
+
+    """
     buffer_map = _load_buffer_map(source, request)
     return {name: buffer.to_xarray() for name, buffer in buffer_map.items()}
 

--- a/tests/test_idpi/test_grib_decoder.py
+++ b/tests/test_idpi/test_grib_decoder.py
@@ -3,7 +3,7 @@ import pytest
 import xarray as xr
 
 # First-party
-from idpi import grib_decoder, data_source
+from idpi import data_source, grib_decoder
 
 
 @pytest.mark.parametrize(

--- a/tests/test_idpi/test_grib_decoder.py
+++ b/tests/test_idpi/test_grib_decoder.py
@@ -3,7 +3,19 @@ import pytest
 import xarray as xr
 
 # First-party
-from idpi import grib_decoder
+from idpi import grib_decoder, data_source
+
+
+@pytest.mark.parametrize(
+    "params,levtype", [(["P", "T", "HHL"], "ml"), (["U_10M", "V_10M"], "sfc")]
+)
+def test_load(params, levtype, request_template, setup_fdb):
+    source = data_source.DataSource()
+    request = request_template | {"param": params, "levtype": levtype}
+    ds = grib_decoder.load(source, request)
+    assert ds.keys() == set(params)
+    assert all(arr.size != 0 for arr in ds.values())
+    assert all(name == arr.parameter["shortName"] for name, arr in ds.items())
 
 
 def test_save(data_dir, tmp_path):

--- a/tests/test_idpi/test_potvortic.py
+++ b/tests/test_idpi/test_potvortic.py
@@ -27,7 +27,7 @@ def data(work_dir, request_template, setup_fdb):
     }
     cache = DataCache(cache_dir=work_dir, fields=fields, files=files)
     cache.populate(source)
-    reader = GribReader(source, ref_param=("HHL", "ml"))
+    reader = GribReader(source)
     yield reader, cache
     cache.clear()
 

--- a/tests/test_idpi/test_radiation.py
+++ b/tests/test_idpi/test_radiation.py
@@ -15,7 +15,7 @@ def test_athd_s(data_dir, fieldextra):
     dd, hh = np.divmod(steps, 24)
     datafiles = [data_dir / f"lfff{d:02d}{h:02d}0000" for d, h in zip(dd, hh)]
 
-    reader = grib_decoder.GribReader.from_files(datafiles, ref_param="T_G")
+    reader = grib_decoder.GribReader.from_files(datafiles)
     ds = reader.load_fieldnames(["ATHB_S", "T_G"])
 
     athb_s = time_ops.resample_average(ds["ATHB_S"], np.timedelta64(1, "h"))

--- a/tests/test_idpi/test_time_ops.py
+++ b/tests/test_idpi/test_time_ops.py
@@ -48,7 +48,7 @@ def test_resample_average(data_dir, fieldextra):
     dd, hh = np.divmod(steps, 24)
     datafiles = [data_dir / f"lfff{d:02d}{h:02d}0000" for d, h in zip(dd, hh)]
 
-    reader = GribReader.from_files(datafiles, ref_param="ASWDIFD_S")
+    reader = GribReader.from_files(datafiles)
     ds = reader.load_fieldnames(["ASWDIFD_S", "ASWDIR_S"])
 
     direct = time_ops.resample_average(ds["ASWDIR_S"], np.timedelta64(1, "h"))
@@ -81,7 +81,7 @@ def test_max(data_dir, fieldextra):
     steps = np.arange(34)
     dd, hh = np.divmod(steps, 24)
     datafiles = [data_dir / f"lfff{d:02d}{h:02d}0000" for d, h in zip(dd, hh)]
-    reader = GribReader.from_files(datafiles, ref_param="VMAX_10M")
+    reader = GribReader.from_files(datafiles)
     ds = reader.load_fieldnames(["VMAX_10M"])
 
     f = ds["VMAX_10M"]
@@ -108,20 +108,20 @@ def test_max(data_dir, fieldextra):
 
 
 def test_get_nsteps():
-    values = pd.date_range("2000-01-01", freq="1H", periods=10)
+    values = pd.date_range("2000-01-01", freq="1h", periods=10)
     valid_time = xr.DataArray(values, dims=["time"])
     assert time_ops.get_nsteps(valid_time, np.timedelta64(5, "h")) == 5
 
 
 def test_get_nsteps_raises_non_uniform():
-    values = pd.date_range("2000-01-01", freq="1H", periods=10)
+    values = pd.date_range("2000-01-01", freq="1h", periods=10)
     valid_time = xr.DataArray(values[[0, 1, 3]], dims=["time"])
     with pytest.raises(ValueError):
         time_ops.get_nsteps(valid_time, np.timedelta64(3, "h"))
 
 
 def test_get_nsteps_raises_non_multiple():
-    values = pd.date_range("2000-01-01", freq="2H", periods=10)
+    values = pd.date_range("2000-01-01", freq="2h", periods=10)
     valid_time = xr.DataArray(values, dims=["time"])
     with pytest.raises(ValueError):
         time_ops.get_nsteps(valid_time, np.timedelta64(3, "h"))


### PR DESCRIPTION
## Purpose

The GribReader only accepts requests for a single paramter at a time. The requests are then dispatched through the tasking mechanism. This is however unfortunate for the polytope datasource as every separate request is queued and processed separately. The present pull request implements a lower level interface that can deal with requests for multiple params. The reader interface remains unchanged.

## Code changes:

- Added `grib_decoder.load` and `grib_decoder.load_single_param` functions.

