### PR TITLE
Add mars request dispatch to data source

### DIFF
--- a/src/idpi/data_source.py
+++ b/src/idpi/data_source.py
@@ -57,7 +57,7 @@ class DataSource:
 
     @singledispatchmethod
     def retrieve(
-        self, request: dict[str, typing.Any] | str | tuple[str, str]
+        self, request: dict[str, typing.Any] | str | tuple[str, str] | mars.Request
     ) -> Iterator:
         """Stream GRIB fields from files or FDB.
 
@@ -67,11 +67,12 @@ class DataSource:
         Simple strings are interpreted as `param` filters and pairs of strings
         are interpreted as `param` and `levtype` filters.
         Key value pairs from the `request_template` attribute are used as default
-        values.
+        values. Note that the default values in the mars request passed as an input
+        will take precedence on the template values.
 
         Parameters
         ----------
-        request : dict | str | tuple[str, str]
+        request : dict | str | tuple[str, str] | idpi.mars.Request
             Request for data from the source in the mars language.
 
         Yields

--- a/src/idpi/grib_decoder.py
+++ b/src/idpi/grib_decoder.py
@@ -18,7 +18,7 @@ import xarray as xr
 from numpy.typing import DTypeLike
 
 # Local
-from . import data_source, metadata, tasking
+from . import data_source, mars, metadata, tasking
 
 logger = logging.getLogger(__name__)
 
@@ -29,7 +29,7 @@ DIM_MAP = {
 }
 INV_DIM_MAP = {v: k for k, v in DIM_MAP.items()}
 
-Request = str | tuple | dict
+Request = str | tuple | dict | mars.Request
 
 
 class GribField(typing.Protocol):

--- a/tests/test_idpi/test_data_source.py
+++ b/tests/test_idpi/test_data_source.py
@@ -72,12 +72,27 @@ def test_retrieve_files_ifs(mock_from_source, mock_grib_def_ctx):
 
 
 def test_retrieve_fdb(mock_from_source, mock_grib_def_ctx):
-    datafiles = []
     param = "U"
     template = {"date": "20200101", "time": "0000"}
 
-    source = data_source.DataSource(datafiles, request_template=template)
+    source = data_source.DataSource(request_template=template)
     for _ in source.retrieve(param):
+        pass
+
+    assert mock_grib_def_ctx.mock_calls == [call("cosmo")]
+    assert mock_from_source.mock_calls == [
+        call("fdb", mars.Request(param, **template).to_fdb()),
+        call().__iter__(),
+    ]
+
+
+def test_retrieve_fdb_mars(mock_from_source, mock_grib_def_ctx):
+    param = "U"
+    request = mars.Request(param=param)
+    template = {"date": "20200101", "time": "0000"}
+
+    source = data_source.DataSource(request_template=template)
+    for _ in source.retrieve(request):
         pass
 
     assert mock_grib_def_ctx.mock_calls == [call("cosmo")]


### PR DESCRIPTION
## Purpose

Add the ability to pass a mars request object to the data source retrieve method. This is a preliminary step for the mch model data module implementation

## Code changes:

- `data_source.DataSource.retrieve` accepts an argument of type `mars.Request`
- The grib definitions context is no longer derived from the request model attribute. In practice, all defined models required the cosmo definitions as IFS grib data does not define the model mars key. Setting `data_scope` config to `ifs` to disable the cosmo definitions context remains possible.
