### PR TITLE
Add mars timeseries feature extension

### DIFF
--- a/src/idpi/mars.py
+++ b/src/idpi/mars.py
@@ -53,6 +53,30 @@ class Type(str, Enum):
     ENS_STD_DEV = "estdv"
 
 
+class FeatureType(str, Enum):
+    TIMESERIES = "timeseries"
+
+
+class Point(typing.NamedTuple):
+    lat: float
+    lon: float
+
+
+@dc.dataclass(frozen=True)
+class TimeseriesFeature:
+    type: FeatureType = FeatureType.TIMESERIES
+    points: list[Point] = dc.field(default_factory=list)
+    start: int = 0
+    end: int = 0
+
+    @pydantic.field_validator("type")
+    @classmethod
+    def validate_type(cls, v: str) -> str:
+        if v != FeatureType.TIMESERIES:
+            raise ValueError("Wrong type")
+        return v
+
+
 @cache
 def _load_mapping():
     mapping_path = files("idpi.data").joinpath("field_mappings.yml")
@@ -87,6 +111,8 @@ class Request:
     model: Model = Model.COSMO_1E
     stream: Stream = Stream.ENS_FORECAST
     type: Type = Type.ENS_MEMBER
+
+    feature: TimeseriesFeature | None = None
 
     def dump(self):
         if pydantic.__version__.startswith("1"):

--- a/tests/test_idpi/test_mars.py
+++ b/tests/test_idpi/test_mars.py
@@ -76,3 +76,22 @@ def test_any_staggering(sample):
     }
 
     assert observed == expected
+
+
+def test_feature_timeseries(sample):
+    feature = mars.TimeseriesFeature(
+        points=[mars.Point(0.1, 0.2)],
+        start=0,
+        end=300,
+    )
+    observed = mars.Request("U", date="20200101", time="0000", feature=feature).to_fdb()
+    expected = sample | {
+        "feature": {
+            "type": "timeseries",
+            "points": [[0.1, 0.2]],
+            "start": 0,
+            "end": 300,
+        }
+    }
+
+    assert observed == expected


### PR DESCRIPTION
## Purpose

Add support for timeseries feature extraction in the mars module. This enables the expression and validation of requests to the polytope gribjump service.

## Code changes:

- Add `feature` attribute to the `mars.Request` class