### PR TITLE
Fix polytope feature extraction

### DIFF
--- a/src/idpi/data_source.py
+++ b/src/idpi/data_source.py
@@ -109,7 +109,7 @@ class DataSource:
             elif self.polytope_collection is not None:
                 pointers = self.polytope_client.retrieve(
                     self.polytope_collection,
-                    req.to_fdb(),
+                    req.to_polytope(),
                     pointer=True,
                     asynchronous=False,
                 )

--- a/src/idpi/data_source.py
+++ b/src/idpi/data_source.py
@@ -114,7 +114,7 @@ class DataSource:
                     asynchronous=False,
                 )
                 urls = [p["location"] for p in pointers]
-                source = ekd.from_source("url", urls)
+                source = ekd.from_source("url", urls, stream=True)
             else:
                 source = ekd.from_source("fdb", req.to_fdb())
             yield from source  # type: ignore

--- a/src/idpi/mars.py
+++ b/src/idpi/mars.py
@@ -160,7 +160,7 @@ class Request:
     def to_polytope(self) -> dict[str, typing.Any]:
         result = self.to_fdb()
         if isinstance(result["param"], list):
-            param = [str(p) for p in result["param"]]
+            param: str | list[str] = [str(p) for p in result["param"]]
         else:
             param = str(result["param"])
         return result | {"param": param, "model": result["model"].lower()}

--- a/src/idpi/mars.py
+++ b/src/idpi/mars.py
@@ -156,7 +156,7 @@ class Request:
         obj = dc.replace(self, levelist=levelist)
         out = typing.cast(dict[str, typing.Any], obj.dump())
         return out | {"param": self._param_id()}
-    
+
     def to_polytope(self) -> dict[str, typing.Any]:
         result = self.to_fdb()
         if isinstance(result["param"], list):

--- a/src/idpi/mars.py
+++ b/src/idpi/mars.py
@@ -130,8 +130,8 @@ class Request:
     def _param_id(self):
         mapping = _load_mapping()
         if isinstance(self.param, Iterable) and not isinstance(self.param, str):
-            return [str(mapping[param]["cosmo"]["paramId"]) for param in self.param]
-        return str(mapping[self.param]["cosmo"]["paramId"])
+            return [mapping[param]["cosmo"]["paramId"] for param in self.param]
+        return mapping[self.param]["cosmo"]["paramId"]
 
     def _staggered(self):
         mapping = _load_mapping()
@@ -155,4 +155,12 @@ class Request:
 
         obj = dc.replace(self, levelist=levelist)
         out = typing.cast(dict[str, typing.Any], obj.dump())
-        return out | {"param": self._param_id(), "model": self.model.lower()}
+        return out | {"param": self._param_id()}
+    
+    def to_polytope(self) -> dict[str, typing.Any]:
+        result = self.to_fdb()
+        if isinstance(result["param"], list):
+            param = [str(p) for p in result["param"]]
+        else:
+            param = str(result["param"])
+        return result | {"param": param, "model": result["model"].lower()}

--- a/src/idpi/mars.py
+++ b/src/idpi/mars.py
@@ -100,8 +100,8 @@ class Request:
 
     expver: str = "0001"
     levelist: int | tuple[int, ...] | None = None
-    number: int | tuple[int, ...] = 0
-    step: int | tuple[int, ...] = 0
+    number: int | tuple[int, ...] | None = None
+    step: int | tuple[int, ...] | None = None
 
     class_: Class = dc.field(
         default=Class.OPERATIONAL_DATA,
@@ -130,8 +130,8 @@ class Request:
     def _param_id(self):
         mapping = _load_mapping()
         if isinstance(self.param, Iterable) and not isinstance(self.param, str):
-            return [mapping[param]["cosmo"]["paramId"] for param in self.param]
-        return mapping[self.param]["cosmo"]["paramId"]
+            return [str(mapping[param]["cosmo"]["paramId"]) for param in self.param]
+        return str(mapping[self.param]["cosmo"]["paramId"])
 
     def _staggered(self):
         mapping = _load_mapping()
@@ -155,4 +155,4 @@ class Request:
 
         obj = dc.replace(self, levelist=levelist)
         out = typing.cast(dict[str, typing.Any], obj.dump())
-        return out | {"param": self._param_id()}
+        return out | {"param": self._param_id(), "model": self.model.lower()}

--- a/src/idpi/mch_model_data.py
+++ b/src/idpi/mch_model_data.py
@@ -79,7 +79,9 @@ def get_from_polytope(request: mars.Request) -> dict[str, xr.DataArray]:
         logger.exception(msg)
         raise RuntimeError(msg)
     if request.feature is not None:
-        collection = "mchgj"
+        source = data_source.DataSource(polytope_collection="mchgj")
+        [result] = source.retrieve(request)
+        return result.to_xarray()
     else:
         collection = "mch"
     logger.info("Getting request %s from polytope collection %s", request, collection)

--- a/tests/test_idpi/conftest.py
+++ b/tests/test_idpi/conftest.py
@@ -90,6 +90,8 @@ def request_template():
         "date": "20230201",
         "expver": "0001",
         "model": "COSMO-1E",
+        "number": 0,
+        "step": 0,
         "stream": "enfo",
         "time": "0300",
         "type": "ememb",

--- a/tests/test_idpi/test_mars.py
+++ b/tests/test_idpi/test_mars.py
@@ -25,7 +25,13 @@ def sample():
 
 
 def test_fdb_defaults(sample):
-    observed = mars.Request("U", date="20200101", time="0000").to_fdb()
+    observed = mars.Request(
+        "U",
+        date="20200101",
+        time="0000",
+        number=0,
+        step=0,
+    ).to_fdb()
     expected = sample
 
     assert observed == expected
@@ -36,6 +42,8 @@ def test_fdb_c2e(sample):
         "U",
         date="20200101",
         time="0000",
+        number=0,
+        step=0,
         model=mars.Model.COSMO_2E,
     ).to_fdb()
     expected = sample | {"model": "COSMO-2E", "levelist": list(range(1, 61))}
@@ -48,6 +56,8 @@ def test_fdb_sfc(sample):
         "HSURF",
         date="20200101",
         time="0000",
+        number=0,
+        step=0,
         levtype=mars.LevType.SURFACE,
     ).to_fdb()
     sample.pop("levelist")
@@ -62,14 +72,26 @@ def test_request_raises():
 
 
 def test_multiple_params(sample):
-    observed = mars.Request(("U", "V"), date="20200101", time="0000").to_fdb()
+    observed = mars.Request(
+        ("U", "V"),
+        date="20200101",
+        time="0000",
+        number=0,
+        step=0,
+    ).to_fdb()
     expected = sample | {"param": [500028, 500030]}
 
     assert observed == expected
 
 
 def test_any_staggering(sample):
-    observed = mars.Request(("U", "V", "W"), date="20200101", time="0000").to_fdb()
+    observed = mars.Request(
+        ("U", "V", "W"),
+        date="20200101",
+        time="0000",
+        number=0,
+        step=0,
+    ).to_fdb()
     expected = sample | {
         "param": [500028, 500030, 500032],
         "levelist": list(range(1, 82)),
@@ -84,14 +106,21 @@ def test_feature_timeseries(sample):
         start=0,
         end=300,
     )
-    observed = mars.Request("U", date="20200101", time="0000", feature=feature).to_fdb()
-    expected = sample | {
+    observed = mars.Request(
+        "U",
+        date="20200101",
+        time="0000",
+        number=1,
+        feature=feature,
+    ).to_fdb()
+    expected = {k: v for k, v in sample.items() if k != "step"} | {
+        "number": 1,
         "feature": {
             "type": "timeseries",
             "points": [[0.1, 0.2]],
             "start": 0,
             "end": 300,
-        }
+        },
     }
 
     assert observed == expected


### PR DESCRIPTION
- polytope gribjump only understands the model mars key when the value is lowercase
- the param value has to be a str
- earthkit data URL source is only iterable when stream=True
- polytope feature extraction returns covjson rather than grib
- when a timeseries feature is requested, the step key is omitted