### PR TITLE
Refactor pot vortic

### DIFF
--- a/src/idpi/data/field_mappings.yml
+++ b/src/idpi/data/field_mappings.yml
@@ -182,3 +182,6 @@ DBZ_CMAX:
 DBZ:
   cosmo:
     paramId: 500174
+POT_VORTIC:
+  cosmo:
+    paramId: 500544

--- a/src/idpi/operators/curl.py
+++ b/src/idpi/operators/curl.py
@@ -27,8 +27,8 @@ def curl(
     tgrlat = cast(xr.DataArray, np.tan(rlat))
 
     # compute weighted derivatives for FD
-    u_f = destagger(u, "x")
-    v_f = destagger(v, "y")
+    u_f = destagger(u, "x") if u.origin_x != 0.0 else u
+    v_f = destagger(v, "y") if v.origin_y != 0.0 else v
     w_f = destagger(w, "z")
 
     du_dz = diff.dz(u_f)

--- a/src/idpi/operators/rho.py
+++ b/src/idpi/operators/rho.py
@@ -7,31 +7,43 @@ import xarray as xr
 from .. import physical_constants as pc
 
 
-def f_rho_tot(
-    T: xr.DataArray,
-    P: xr.DataArray,
-    QV: xr.DataArray,
-    QC: xr.DataArray,
-    QI: xr.DataArray | None = None,
-    QP: xr.DataArray | None = None,
+def compute_rho_tot(
+    t: xr.DataArray,
+    p: xr.DataArray,
+    qv: xr.DataArray,
+    qc: xr.DataArray,
+    qi: xr.DataArray | None = None,
+    qp: xr.DataArray | None = None,
 ) -> xr.DataArray:
     """Total density of air mixture.
 
     Assumes perfect gas law, pressure as sum of partial pressures.
-    Result is in [kg/m**3].
 
-    Args:
-        T (xr.DataArray): Temperature [Kelvin]
-        P (xr.DataArray): Pressure [Pascal]
-        QV (xr.DataArray): Specific humidity [kg/kg]
-        QC (xr.DataArray): Specific cloud water content [kg/kg]
-        QI (xr.DataArray, optional): Specific cloud ice content [kg/kg].
-        QP (xr.DataArray, optional): Specific precipitable components content [kg/kg].
+    Parameters
+    ----------
+    t : xarray.DataArray
+        Temperature [Kelvin]
+    p : xarray.DataArray
+        Pressure [Pascal]
+    qv : xarray.DataArray
+        Specific humidity [kg/kg]
+    qc : xarray.DataArray
+        Specific cloud water content [kg/kg]
+    qi : xarray.DataArray, optional
+        Specific cloud ice content [kg/kg]
+    qp : xarray.DataArray, optional
+        Specific precipitable components content [kg/kg]
+
+    Returns
+    -------
+    xarray.DataArray
+        Total density of air mixture [kg/m**3]
 
     """
-    q = QC
-    if QI is not None:
-        q += QI
-    if QP is not None:
-        q += QP
-    return P / (pc.r_d * T * (1.0 + pc.rvd_o * QV - q))
+    q = qc
+    if qi is not None:
+        q += qi
+    if qp is not None:
+        q += qp
+
+    return p / (pc.r_d * t * (1.0 + pc.rvd_o * qv - q))

--- a/src/idpi/operators/theta.py
+++ b/src/idpi/operators/theta.py
@@ -4,24 +4,30 @@
 import xarray as xr
 
 # Local
+from .. import metadata
 from .. import physical_constants as pc
 
 
-def ftheta(p: xr.DataArray, t: xr.DataArray) -> xr.DataArray:
+def compute_theta(p: xr.DataArray, t: xr.DataArray) -> xr.DataArray:
     """Potential temperature in K.
 
-    Args:
-        p (xr.DataArray): pressure in Pa
-        t (xr.DataArray): air temperature in K
+    Parameters
+    ----------
+    p : xarray.DataArray
+        pressure in Pa
+    t : xarray.DataArray
+        air temperature in K
 
-    Returns:
-        xr.DataArray: potential temperature in K
+    Returns
+    -------
+    xr.DataArray
+        potential temperature in K
 
     """
     # Reference surface pressure for computation of potential temperature
     p0 = 1.0e5
 
     result = (p0 / p) ** pc.rdocp * t
-    result.attrs = p.attrs | {"parameter": None}
+    result.attrs = metadata.override(p.message, shortName="PT")
 
     return result

--- a/src/idpi/operators/theta.py
+++ b/src/idpi/operators/theta.py
@@ -20,7 +20,7 @@ def compute_theta(p: xr.DataArray, t: xr.DataArray) -> xr.DataArray:
 
     Returns
     -------
-    xr.DataArray
+    xarray.DataArray
         potential temperature in K
 
     """

--- a/tests/test_idpi/test_curl.py
+++ b/tests/test_idpi/test_curl.py
@@ -3,10 +3,11 @@ import numpy as np
 from xarray.testing import assert_allclose
 
 # First-party
-from idpi.grib_decoder import GribReader
+from idpi.data_source import DataSource
+from idpi.grib_decoder import load
 from idpi.metadata import set_origin_xy
 from idpi.operators import curl
-from idpi.operators.support_operators import get_grid_coords
+from idpi.operators.gis import get_grid
 from idpi.operators.total_diff import TotalDiff
 
 
@@ -14,17 +15,12 @@ def test_curl(data_dir):
     datafile = data_dir / "COSMO-1E/1h/ml_sl/000/lfff00000000"
     cdatafile = data_dir / "COSMO-1E/1h/const/000/lfff00000000c"
 
-    reader = GribReader.from_files([cdatafile, datafile])
-    ds = reader.load_fieldnames(["U", "V", "W", "HHL"])
+    source = DataSource(datafiles=[cdatafile, datafile])
+    ds = load(source, {"param": ["U", "V", "W", "HHL"]})
     set_origin_xy(ds, ref_param="HHL")
 
-    geo = ds["HHL"].attrs["geography"]
-    dlat = geo["jDirectionIncrementInDegrees"]
-    nj = geo["Nj"]
-    lat_min = geo["latitudeOfFirstGridPointInDegrees"]
-
     deg2rad = np.pi / 180
-    rlat = get_grid_coords(nj, lat_min, dlat, "y") * deg2rad
+    rlat = get_grid(ds["HHL"].attrs["geography"]).rlat * deg2rad
     total_diff = TotalDiff.from_hhl(ds["HHL"])
 
     a1, a2, a3 = curl.curl(ds["U"], ds["V"], ds["W"], rlat, total_diff)

--- a/tests/test_idpi/test_curl.py
+++ b/tests/test_idpi/test_curl.py
@@ -19,14 +19,13 @@ def test_curl(data_dir):
     set_origin_xy(ds, ref_param="HHL")
 
     geo = ds["HHL"].attrs["geography"]
-    dlon = geo["iDirectionIncrementInDegrees"]
     dlat = geo["jDirectionIncrementInDegrees"]
     nj = geo["Nj"]
     lat_min = geo["latitudeOfFirstGridPointInDegrees"]
 
     deg2rad = np.pi / 180
     rlat = get_grid_coords(nj, lat_min, dlat, "y") * deg2rad
-    total_diff = TotalDiff(dlon * deg2rad, dlat * deg2rad, ds["HHL"])
+    total_diff = TotalDiff.from_hhl(ds["HHL"])
 
     a1, a2, a3 = curl.curl(ds["U"], ds["V"], ds["W"], rlat, total_diff)
     b1, b2, b3 = curl.curl_alt(ds["U"], ds["V"], ds["W"], rlat, total_diff)

--- a/tests/test_idpi/test_diff.py
+++ b/tests/test_idpi/test_diff.py
@@ -5,7 +5,7 @@ from numpy.testing import assert_allclose
 # First-party
 from idpi.grib_decoder import GribReader
 from idpi.operators import diff
-from idpi.operators.theta import ftheta
+from idpi.operators.theta import compute_theta
 
 
 def test_masspoint_field(data_dir):
@@ -14,7 +14,7 @@ def test_masspoint_field(data_dir):
 
     ds = reader.load_fieldnames(["P", "T"])
 
-    theta = ftheta(ds["P"], ds["T"])
+    theta = compute_theta(ds["P"], ds["T"])
 
     padding = [(0, 0)] * 2 + [(1, 1)] * 3
     tp = np.pad(theta, padding, mode="edge")

--- a/tests/test_idpi/test_intpl_k2theta.py
+++ b/tests/test_idpi/test_intpl_k2theta.py
@@ -5,7 +5,7 @@ from numpy.testing import assert_allclose
 # First-party
 from idpi.grib_decoder import GribReader
 from idpi.operators.destagger import destagger
-from idpi.operators.theta import ftheta
+from idpi.operators.theta import compute_theta
 from idpi.operators.vertical_interpolation import interpolate_k2theta
 
 
@@ -26,7 +26,7 @@ def test_intpl_k2theta(mode, data_dir, fieldextra):
 
     ds = reader.load_fieldnames(["P", "T", "HHL"])
 
-    theta = ftheta(ds["P"], ds["T"])
+    theta = compute_theta(ds["P"], ds["T"])
     hfl = destagger(ds["HHL"], "z")
 
     # call interpolation operator

--- a/tests/test_idpi/test_potvortic.py
+++ b/tests/test_idpi/test_potvortic.py
@@ -6,7 +6,7 @@ from numpy.testing import assert_allclose
 import idpi.operators.pot_vortic as pv
 from idpi.data_cache import DataCache
 from idpi.data_source import DataSource
-from idpi.grib_decoder import GribReader
+from idpi.grib_decoder import load
 from idpi.metadata import set_origin_xy
 from idpi.operators.rho import compute_rho_tot
 from idpi.operators.theta import compute_theta
@@ -25,14 +25,13 @@ def data(work_dir, request_template, setup_fdb):
     }
     cache = DataCache(cache_dir=work_dir, fields=fields, files=files)
     cache.populate(source)
-    reader = GribReader(source)
-    yield reader, cache
+    yield source, cache
     cache.clear()
 
 
 def test_pv(data, fieldextra):
-    reader, cache = data
-    ds = reader.load_fieldnames(["U", "V", "W", "P", "T", "QV", "QC", "QI", "HHL"])
+    source, cache = data
+    ds = load(source, {"param": ["U", "V", "W", "P", "T", "QV", "QC", "QI", "HHL"]})
     set_origin_xy(ds, ref_param="HHL")
 
     theta = compute_theta(ds["P"], ds["T"])

--- a/tests/test_idpi/test_theta.py
+++ b/tests/test_idpi/test_theta.py
@@ -2,7 +2,7 @@
 from numpy.testing import assert_allclose
 
 # First-party
-import idpi.operators.theta as mtheta
+from idpi.operators.theta import compute_theta
 from idpi.grib_decoder import GribReader
 
 
@@ -12,7 +12,7 @@ def test_theta(data_dir, fieldextra):
 
     ds = reader.load_fieldnames(["P", "T"])
 
-    theta = mtheta.ftheta(ds["P"], ds["T"])
+    theta = compute_theta(ds["P"], ds["T"])
 
     fs_ds = fieldextra("THETA")
 

--- a/tests/test_idpi/test_theta.py
+++ b/tests/test_idpi/test_theta.py
@@ -2,8 +2,8 @@
 from numpy.testing import assert_allclose
 
 # First-party
-from idpi.operators.theta import compute_theta
 from idpi.grib_decoder import GribReader
+from idpi.operators.theta import compute_theta
 
 
 def test_theta(data_dir, fieldextra):

--- a/tests/test_idpi/test_total_diff.py
+++ b/tests/test_idpi/test_total_diff.py
@@ -5,7 +5,7 @@ from numpy.testing import assert_allclose
 # First-party
 from idpi.grib_decoder import GribReader
 from idpi.operators import diff
-from idpi.operators.theta import ftheta
+from idpi.operators.theta import compute_theta
 from idpi.operators.total_diff import TotalDiff
 
 
@@ -48,14 +48,14 @@ def test_total_diff(data_dir):
         )
     )
 
-    total_diff = TotalDiff(dlon, dlat, ds["HHL"].squeeze())
+    total_diff = TotalDiff.from_hhl(ds["HHL"].squeeze())
 
     assert_allclose(total_diff.sqrtg_r_s.values, sqrtg_r_s)
     assert_allclose(total_diff.dzeta_dlam.values, dzeta_dlam, rtol=1e-6)
     assert_allclose(total_diff.dzeta_dphi.values, dzeta_dphi, rtol=1e-6)
 
     ds = reader.load_fieldnames(["P", "T"])
-    theta = ftheta(ds["P"], ds["T"])
+    theta = compute_theta(ds["P"], ds["T"])
 
     padding = [(0, 0)] * 2 + [(1, 1)] * 3
     tp = np.pad(theta, padding, mode="edge")


### PR DESCRIPTION
## Purpose

Enable passing non staggered fields U and V to compute potential vorticity. Some housekeeping is done to improve the consistency of the documentation and naming. 

## Code Changes

- renamed `fpotvortic` to `compute_pot_vortic`, replaced `total_diff` argument with `hhl` 
- renamed `ftheta` to `compute_theta`
- renamed `f_rho_tot` to `compute_rho_tot`
- `compute_pot_vortic` uses the HHL grid as a reference
- Added `TotalDiff.from_hhl` classmethod
- `compute_pot_vortic` and `compute_theta` now update the metadata