### PR TITLE
Fix archive_to_fdb

### DIFF
--- a/src/idpi/grib_decoder.py
+++ b/src/idpi/grib_decoder.py
@@ -344,7 +344,11 @@ class GribReader:
         return self.load(reqs, extract_pv)
 
 
-def save(field: xr.DataArray, file_handle: io.BufferedWriter, bits_per_value: int = 16):
+def save(
+    field: xr.DataArray,
+    file_handle: io.BufferedWriter | io.BytesIO,
+    bits_per_value: int = 16,
+):
     """Write field to file in GRIB format.
 
     Parameters

--- a/src/idpi/mch_model_data.py
+++ b/src/idpi/mch_model_data.py
@@ -11,7 +11,6 @@ import logging
 import os
 
 # Third-party
-import pyfdb  # type: ignore
 import xarray as xr
 
 # Local
@@ -116,9 +115,11 @@ def archive_to_fdb(
         Bits per value encoded in the archived data. (Default: 16)
 
     """
+    # Third-party
+    import pyfdb  # type: ignore
+
     buffer = io.BytesIO()
-    handle = io.BufferedWriter(buffer.raw)
-    grib_decoder.save(field, handle, bits_per_value)
+    grib_decoder.save(field, buffer, bits_per_value)
     fdb = pyfdb.FDB()
     req = request.to_fdb() if request is not None else None
     if request is not None:


### PR DESCRIPTION
- io.BytesIO is missing the raw attribute
- pyfdb should be an optional dependency of idpi